### PR TITLE
fix(ci): pin Docsy v0.12.0 and add release-drafter fallback tag

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,6 +21,7 @@ jobs:
           minorList: feat, feature
           patchList: fix, bugfix, perf, refactor, test, tests, chore, doc
           skipInvalidTags: true
+          fallbackTag: v0.0.0
       - name: Draft Release
         uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7
         env:

--- a/website/go.mod
+++ b/website/go.mod
@@ -1,3 +1,5 @@
 module github.com/nextdoor/vigil-controller/website
 
 go 1.24.0
+
+require github.com/google/docsy v0.12.0 // indirect

--- a/website/go.sum
+++ b/website/go.sum
@@ -1,0 +1,2 @@
+github.com/google/docsy v0.12.0 h1:CddZKL39YyJzawr8GTVaakvcUTCJRAAYdz7W0qfZ2P4=
+github.com/google/docsy v0.12.0/go.mod h1:1bioDqA493neyFesaTvQ9reV0V2vYy+xUAnlnz7+miM=

--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -7,7 +7,7 @@ defaultContentLanguageInSubdir: false
 module:
   hugoVersion:
     extended: true
-    min: "0.146.0"
+    min: "0.125.0"
   imports:
     - path: github.com/google/docsy
       disable: false


### PR DESCRIPTION
## Summary
- Pin `google/docsy` to v0.12.0 in `website/go.mod` — v0.14.3 has a broken i18n file incompatible with Hugo 0.147.0 (same issue hit Lumina in #175)
- Add `fallbackTag: v0.0.0` to release-drafter semver action so it works on repos with no existing tags
- Lower Hugo min version requirement to 0.125.0 for broader compatibility

## Test plan
- [ ] `docs.yml` workflow succeeds after merge (Hugo builds the site)
- [ ] `release-drafter.yml` workflow succeeds after merge (creates draft release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)