### PR TITLE
feat(chart): add priorityClassName support

### DIFF
--- a/charts/vigil-controller/templates/deployment.yaml
+++ b/charts/vigil-controller/templates/deployment.yaml
@@ -99,6 +99,9 @@ spec:
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/vigil-controller/values.yaml
+++ b/charts/vigil-controller/values.yaml
@@ -69,6 +69,8 @@ readinessProbe:
   initialDelaySeconds: 5
   periodSeconds: 10
 
+# -- Priority class name for the controller pods
+priorityClassName: ""
 # -- Node selector
 nodeSelector: {}
 # -- Tolerations


### PR DESCRIPTION
## Summary
- Adds `priorityClassName` value to the vigil-controller Helm chart
- Defaults to empty string (no priority class set)
- Needed by the k8s repo to set `system-cluster-critical` on Vigil pods

## Test plan
- [ ] `helm template` renders correctly with and without `priorityClassName` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)