### PR TITLE
perf(cache): shrink Pod informer cache; harden stress benchmark

### DIFF
--- a/.claude/skills/stress-test/SKILL.md
+++ b/.claude/skills/stress-test/SKILL.md
@@ -39,7 +39,11 @@ Vigil Stress Test — usage:
 Environment overrides (via STRESS_* env vars):
   STRESS_NODE_COUNT, STRESS_NODE_RATE, STRESS_TIMEOUT_MINUTES,
   STRESS_CONTROLLER_TIMEOUT_SEC, STRESS_MAX_CONCURRENT_RECONCILES,
-  STRESS_API_CONCURRENCY, STRESS_LOG_LEVEL (0=warn, 1=info, 2=debug)
+  STRESS_API_CONCURRENCY, STRESS_LOG_LEVEL (0=warn, 1=info, 2=debug),
+  STRESS_BACKGROUND_PODS (default 15000 — non-DS pods that sit in the
+    informer cache, simulating real workloads),
+  STRESS_BACKGROUND_POD_MIN_BYTES (default 5120),
+  STRESS_BACKGROUND_POD_MAX_BYTES (default 15360)
 
 Files:
   test/stress/baseline.json          Checked-in baseline for regression detection

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ website/node_modules/
 website/public/
 website/resources/
 website/.hugo_build.lock
+
+# Claude Code scheduled-task state
+.claude/scheduled_tasks.lock

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/nextdoor/vigil/internal/cacheopts"
 	"github.com/nextdoor/vigil/internal/controller"
 	"github.com/nextdoor/vigil/internal/discovery"
 	"github.com/nextdoor/vigil/internal/inventory"
@@ -114,6 +115,7 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
+		Cache:                         cacheopts.New(),
 		HealthProbeBindAddress:        probeAddr,
 		LeaderElection:                enableLeaderElection,
 		LeaderElectionID:              "vigil-controller.nextdoor.com",

--- a/internal/cacheopts/cacheopts.go
+++ b/internal/cacheopts/cacheopts.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Nextdoor, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cacheopts builds the controller-runtime cache configuration used by
+// both the production binary and the stress harness. The shared definition
+// keeps the stress-test memory numbers apples-to-apples with what ships.
+package cacheopts
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TransformPod strips every pod field vigil does not read before the object
+// enters the informer cache. On a large cluster (tens of thousands of pods)
+// this is the difference between a several-hundred-megabyte cache and a small
+// one — fat fields like ManagedFields, annotations, container statuses, env
+// vars, and volume specs dominate in-cache pod size.
+//
+// Fields preserved — every field the controller actually reads:
+//   - metadata.name, namespace, uid, resourceVersion
+//   - metadata.labels (small, useful for log context)
+//   - metadata.ownerReferences (checked for DaemonSet ownership)
+//   - spec.nodeName (required for the .spec.nodeName field indexer)
+//   - status.phase and the PodReady condition (readiness check)
+//
+// Everything else is cleared. Updating this list means updating the readiness
+// package in lockstep.
+func TransformPod(obj any) (any, error) {
+	// Informer delete events may arrive as a tombstone wrapping the last
+	// known object. Pass those through untouched.
+	if _, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
+		return obj, nil
+	}
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pod.Name,
+			Namespace:       pod.Namespace,
+			UID:             pod.UID,
+			ResourceVersion: pod.ResourceVersion,
+			Labels:          pod.Labels,
+			OwnerReferences: pod.OwnerReferences,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: pod.Spec.NodeName,
+		},
+		Status: corev1.PodStatus{
+			Phase:      pod.Status.Phase,
+			Conditions: podReadyConditionOnly(pod.Status.Conditions),
+		},
+	}, nil
+}
+
+func podReadyConditionOnly(in []corev1.PodCondition) []corev1.PodCondition {
+	for _, c := range in {
+		if c.Type == corev1.PodReady {
+			return []corev1.PodCondition{c}
+		}
+	}
+	return nil
+}
+
+// New returns the cache.Options the manager should use. A pod Transform is
+// always applied; ManagedFields is also stripped from every other type via
+// the default transform.
+func New() cache.Options {
+	return cache.Options{
+		DefaultTransform: cache.TransformStripManagedFields(),
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}: {Transform: TransformPod},
+		},
+	}
+}

--- a/internal/cacheopts/cacheopts_test.go
+++ b/internal/cacheopts/cacheopts_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Nextdoor, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cacheopts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	toolscache "k8s.io/client-go/tools/cache"
+)
+
+func TestTransformPod_PreservesFieldsVigilReads(t *testing.T) {
+	controller := true
+	in := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "ds-pod",
+			Namespace:       "kube-system",
+			UID:             "pod-uid",
+			ResourceVersion: "42",
+			Labels:          map[string]string{"app": "foo"},
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "foo", UID: "ds-uid", Controller: &controller},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodInitialized, Status: corev1.ConditionTrue},
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	out, err := TransformPod(in)
+	require.NoError(t, err)
+	pod, ok := out.(*corev1.Pod)
+	require.True(t, ok)
+
+	assert.Equal(t, "ds-pod", pod.Name)
+	assert.Equal(t, "kube-system", pod.Namespace)
+	assert.Equal(t, "pod-uid", string(pod.UID))
+	assert.Equal(t, "42", pod.ResourceVersion)
+	assert.Equal(t, "foo", pod.Labels["app"])
+	assert.Equal(t, "node-1", pod.Spec.NodeName)
+	assert.Equal(t, corev1.PodRunning, pod.Status.Phase)
+	require.Len(t, pod.OwnerReferences, 1)
+	assert.Equal(t, "DaemonSet", pod.OwnerReferences[0].Kind)
+	require.Len(t, pod.Status.Conditions, 1)
+	assert.Equal(t, corev1.PodReady, pod.Status.Conditions[0].Type)
+	assert.Equal(t, corev1.ConditionTrue, pod.Status.Conditions[0].Status)
+}
+
+func TestTransformPod_StripsFatFields(t *testing.T) {
+	in := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fat-pod",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubectl", Operation: metav1.ManagedFieldsOperationUpdate},
+			},
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": "really long blob here",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "n",
+			Containers: []corev1.Container{
+				{Name: "c", Image: "x", Env: []corev1.EnvVar{{Name: "E", Value: "v"}}},
+			},
+			Volumes: []corev1.Volume{{Name: "v"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			HostIP:            "10.0.0.1",
+			PodIP:             "10.0.0.2",
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "c", Image: "x", ImageID: "sha256:deadbeef"}},
+		},
+	}
+
+	out, err := TransformPod(in)
+	require.NoError(t, err)
+	pod := out.(*corev1.Pod)
+
+	assert.Nil(t, pod.ManagedFields)
+	assert.Nil(t, pod.Annotations)
+	assert.Empty(t, pod.Spec.Containers)
+	assert.Empty(t, pod.Spec.Volumes)
+	assert.Empty(t, pod.Status.ContainerStatuses)
+	assert.Empty(t, pod.Status.HostIP)
+	assert.Empty(t, pod.Status.PodIP)
+}
+
+func TestTransformPod_KeepsOnlyPodReadyCondition(t *testing.T) {
+	in := &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodInitialized, Status: corev1.ConditionTrue},
+				{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+				{Type: corev1.ContainersReady, Status: corev1.ConditionTrue},
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+	out, _ := TransformPod(in)
+	pod := out.(*corev1.Pod)
+	require.Len(t, pod.Status.Conditions, 1)
+	assert.Equal(t, corev1.PodReady, pod.Status.Conditions[0].Type)
+	assert.Equal(t, corev1.ConditionFalse, pod.Status.Conditions[0].Status)
+}
+
+func TestTransformPod_NoPodReadyCondition(t *testing.T) {
+	in := &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodInitialized, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	out, _ := TransformPod(in)
+	pod := out.(*corev1.Pod)
+	assert.Nil(t, pod.Status.Conditions)
+}
+
+func TestTransformPod_PassesThroughTombstone(t *testing.T) {
+	tombstone := toolscache.DeletedFinalStateUnknown{Key: "default/pod-1", Obj: &corev1.Pod{}}
+	out, err := TransformPod(tombstone)
+	require.NoError(t, err)
+	assert.Equal(t, tombstone, out)
+}
+
+func TestTransformPod_PassesThroughNonPod(t *testing.T) {
+	in := "not-a-pod"
+	out, err := TransformPod(in)
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
+func TestNew_RegistersPodTransform(t *testing.T) {
+	opts := New()
+	require.NotNil(t, opts.DefaultTransform)
+
+	var found bool
+	for k, v := range opts.ByObject {
+		if _, ok := k.(*corev1.Pod); ok {
+			require.NotNil(t, v.Transform)
+			found = true
+		}
+	}
+	require.True(t, found, "expected a Pod entry in ByObject")
+}

--- a/test/stress/backgroundpods_test.go
+++ b/test/stress/backgroundpods_test.go
@@ -1,0 +1,185 @@
+//go:build stress
+
+// Copyright 2026 Nextdoor, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stress
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Pods unrelated to DaemonSets sit in the informer cache even though the
+// controller never reconciles against them. Real clusters have tens of
+// thousands of them, each padded with ManagedFields, annotations, env, and
+// container statuses — the cache bloat from this is what dominates controller
+// memory in production. Stress runs need to include them or the memory number
+// is meaningless.
+func createBackgroundPods(
+	ctx context.Context,
+	cl client.Client,
+	count int,
+	nodeCount int,
+	minBytes, maxBytes int,
+	concurrency int,
+) error {
+	if count <= 0 {
+		return nil
+	}
+
+	rng := rand.New(rand.NewSource(1337)) //nolint:gosec // deterministic for reproducibility
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	var firstErrMu sync.Mutex
+	var firstErr error
+
+	for i := range count {
+		size := minBytes + rng.Intn(maxBytes-minBytes+1)
+		nodeIdx := i % nodeCount
+		pod := buildBackgroundPod(i, nodeIdx, size, rng)
+
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		wg.Add(1)
+		go func(p *corev1.Pod) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if err := cl.Create(ctx, p); err != nil {
+				firstErrMu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				firstErrMu.Unlock()
+			}
+		}(pod)
+	}
+
+	wg.Wait()
+	return firstErr
+}
+
+// buildBackgroundPod returns a ReplicaSet-owned pod whose serialized size
+// lands near targetBytes. The padding comes from a single large annotation —
+// conceptually the same as a real pod's last-applied-configuration blob.
+func buildBackgroundPod(idx, nodeIdx, targetBytes int, rng *rand.Rand) *corev1.Pod {
+	const baseOverhead = 800 // rough non-filler object size
+	fillerLen := targetBytes - baseOverhead
+	if fillerLen < 0 {
+		fillerLen = 0
+	}
+	filler := randomASCII(rng, fillerLen)
+
+	rsIdx := idx % 100
+	rsName := fmt.Sprintf("bg-rs-%03d", rsIdx)
+	rsUID := types.UID(fmt.Sprintf("00000000-0000-0000-0000-%012d", rsIdx))
+	ctrl := true
+
+	imageID := "docker.io/library/example@sha256:" + randomHex(rng, 64)
+	containerID := "containerd://" + randomHex(rng, 64)
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      fmt.Sprintf("bg-pod-%06d", idx),
+			Labels: map[string]string{
+				"app":                          rsName,
+				"tier":                         "backend",
+				"pod-template-hash":            fmt.Sprintf("%d", rsIdx),
+				"app.kubernetes.io/managed-by": "stress-test",
+			},
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": filler,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+					Name:       rsName,
+					UID:        rsUID,
+					Controller: &ctrl,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: fmt.Sprintf("stress-node-%05d", nodeIdx),
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "example/app:v1.2.3",
+					Env: []corev1.EnvVar{
+						{Name: "FOO", Value: "bar"},
+						{Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+						}},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "app",
+					Ready:        true,
+					RestartCount: 0,
+					Image:        "example/app:v1.2.3",
+					ImageID:      imageID,
+					ContainerID:  containerID,
+					Started:      boolPtr(true),
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Time{Time: time.Now().Add(-time.Hour)},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func randomASCII(rng *rand.Rand, n int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 "
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = charset[rng.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func randomHex(rng *rand.Rand, n int) string {
+	const hex = "0123456789abcdef"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = hex[rng.Intn(16)]
+	}
+	return string(b)
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/test/stress/baseline.json
+++ b/test/stress/baseline.json
@@ -1,30 +1,33 @@
 {
-  "timestamp": "2026-03-28T21:50:52Z",
-  "git_sha": "1577d67",
+  "timestamp": "2026-04-17T02:48:44Z",
+  "git_sha": "ea4a07f",
   "test_config": {
     "node_count": 10000,
     "node_rate": 10,
-    "timeout_minutes": 30,
+    "timeout_minutes": 40,
     "controller_timeout_sec": 30,
     "max_concurrent_reconciles": 50,
     "api_concurrency": 150,
-    "daemonset_count": 3
+    "daemonset_count": 3,
+    "background_pods": 15000,
+    "background_pod_min_bytes": 5120,
+    "background_pod_max_bytes": 15360
   },
   "latency": {
     "end_to_end": {
-      "p50_ms": 5023,
-      "p95_ms": 30206,
-      "p99_ms": 30416
+      "p50_ms": 5020,
+      "p95_ms": 32136,
+      "p99_ms": 34222
     },
     "pod_startup": {
-      "p50_ms": 3761,
-      "p95_ms": 38220,
-      "p99_ms": 51901
+      "p50_ms": 3760,
+      "p95_ms": 38202,
+      "p99_ms": 52232
     },
     "vigil_reaction": {
-      "p50_ms": 1000,
-      "p95_ms": 1901,
-      "p99_ms": 1981
+      "p50_ms": 999,
+      "p95_ms": 1908,
+      "p99_ms": 1979
     }
   },
   "counts": {
@@ -40,1696 +43,1688 @@
     "never-ready": 500
   },
   "memory": {
-    "peak_heap_alloc_mb": 275.84458923339844,
-    "final_heap_alloc_mb": 224.08172607421875,
-    "final_sys_mb": 315.1575393676758,
-    "total_gc_cycles": 229,
-    "gc_cpu_fraction": 0.0003155671325870182
+    "peak_heap_alloc_mb": 222.72119903564453,
+    "final_heap_alloc_mb": 193.04774475097656,
+    "final_sys_mb": 290.9124221801758,
+    "total_gc_cycles": 280,
+    "gc_cpu_fraction": 0.0002842996654169435
   },
   "resource_samples": [
     {
-      "elapsed_sec": 5.000641375,
-      "heap_alloc_mb": 7.91510009765625,
-      "sys_mb": 23.14185333251953,
-      "num_gc": 11,
-      "num_goroutine": 140,
-      "gc_cpu_fraction": 0.0004088853593179173
-    },
-    {
-      "elapsed_sec": 10.000872083,
-      "heap_alloc_mb": 7.837669372558594,
-      "sys_mb": 27.89185333251953,
-      "num_gc": 20,
-      "num_goroutine": 152,
-      "gc_cpu_fraction": 0.0005341748894740957
-    },
-    {
-      "elapsed_sec": 15.0003625,
-      "heap_alloc_mb": 6.604377746582031,
-      "sys_mb": 27.89185333251953,
-      "num_gc": 28,
-      "num_goroutine": 164,
-      "gc_cpu_fraction": 0.0006418782758747693
-    },
-    {
-      "elapsed_sec": 20.001743291,
-      "heap_alloc_mb": 8.73956298828125,
-      "sys_mb": 32.14185333251953,
-      "num_gc": 35,
-      "num_goroutine": 176,
-      "gc_cpu_fraction": 0.0006456513754391696
-    },
-    {
-      "elapsed_sec": 25.000611,
-      "heap_alloc_mb": 9.959732055664062,
-      "sys_mb": 32.39185333251953,
-      "num_gc": 42,
-      "num_goroutine": 184,
-      "gc_cpu_fraction": 0.0006827690938005104
-    },
-    {
-      "elapsed_sec": 30.00059475,
-      "heap_alloc_mb": 9.756240844726562,
-      "sys_mb": 32.39185333251953,
-      "num_gc": 48,
-      "num_goroutine": 184,
-      "gc_cpu_fraction": 0.0007352910520172616
-    },
-    {
-      "elapsed_sec": 35.0009645,
-      "heap_alloc_mb": 13.195953369140625,
-      "sys_mb": 36.39185333251953,
-      "num_gc": 53,
-      "num_goroutine": 184,
-      "gc_cpu_fraction": 0.0007907936460692332
-    },
-    {
-      "elapsed_sec": 40.000785708,
-      "heap_alloc_mb": 10.9195556640625,
-      "sys_mb": 36.39185333251953,
-      "num_gc": 58,
-      "num_goroutine": 185,
-      "gc_cpu_fraction": 0.0008007334054103934
-    },
-    {
-      "elapsed_sec": 45.000295416,
-      "heap_alloc_mb": 15.440101623535156,
-      "sys_mb": 36.39185333251953,
-      "num_gc": 62,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.0007929038920016771
-    },
-    {
-      "elapsed_sec": 50.00089875,
-      "heap_alloc_mb": 16.98352813720703,
-      "sys_mb": 40.39185333251953,
-      "num_gc": 66,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.0007711725935250876
-    },
-    {
-      "elapsed_sec": 55.000822291,
-      "heap_alloc_mb": 17.5615234375,
-      "sys_mb": 40.39185333251953,
-      "num_gc": 70,
-      "num_goroutine": 205,
-      "gc_cpu_fraction": 0.00075875311603336
-    },
-    {
-      "elapsed_sec": 60.000935416,
-      "heap_alloc_mb": 20.441207885742188,
-      "sys_mb": 44.64185333251953,
-      "num_gc": 74,
-      "num_goroutine": 201,
-      "gc_cpu_fraction": 0.0007432113608423283
-    },
-    {
-      "elapsed_sec": 65.000976333,
-      "heap_alloc_mb": 16.10987091064453,
-      "sys_mb": 44.64185333251953,
-      "num_gc": 79,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.0007186905520121105
-    },
-    {
-      "elapsed_sec": 70.000519125,
-      "heap_alloc_mb": 20.052955627441406,
-      "sys_mb": 44.64185333251953,
-      "num_gc": 82,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0006954784750416937
-    },
-    {
-      "elapsed_sec": 75.000981708,
-      "heap_alloc_mb": 23.500343322753906,
-      "sys_mb": 44.70435333251953,
-      "num_gc": 85,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.0006794550546940216
-    },
-    {
-      "elapsed_sec": 80.000515916,
-      "heap_alloc_mb": 17.66606903076172,
-      "sys_mb": 48.70435333251953,
-      "num_gc": 89,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.0006652783389305825
-    },
-    {
-      "elapsed_sec": 85.001015333,
-      "heap_alloc_mb": 22.8387451171875,
-      "sys_mb": 48.76685333251953,
-      "num_gc": 92,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0006722355560515793
-    },
-    {
-      "elapsed_sec": 90.001047833,
-      "heap_alloc_mb": 27.69477081298828,
-      "sys_mb": 48.82935333251953,
-      "num_gc": 95,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.0006635540803958171
-    },
-    {
-      "elapsed_sec": 95.000233125,
-      "heap_alloc_mb": 23.901931762695312,
-      "sys_mb": 53.07935333251953,
-      "num_gc": 98,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0006454892108227604
-    },
-    {
-      "elapsed_sec": 100.00091075,
-      "heap_alloc_mb": 31.412078857421875,
-      "sys_mb": 53.07935333251953,
-      "num_gc": 100,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.000642308683790474
-    },
-    {
-      "elapsed_sec": 105.00030225,
-      "heap_alloc_mb": 24.237747192382812,
-      "sys_mb": 57.07935333251953,
-      "num_gc": 103,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.0006358235128486289
-    },
-    {
-      "elapsed_sec": 110.001159291,
-      "heap_alloc_mb": 30.58782196044922,
-      "sys_mb": 57.07935333251953,
-      "num_gc": 105,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.0006241077972153923
-    },
-    {
-      "elapsed_sec": 115.000898875,
-      "heap_alloc_mb": 36.60474395751953,
-      "sys_mb": 61.07935333251953,
-      "num_gc": 107,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0006129754615485277
-    },
-    {
-      "elapsed_sec": 120.001425583,
-      "heap_alloc_mb": 40.49956512451172,
-      "sys_mb": 61.07935333251953,
-      "num_gc": 109,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0006039326496611613
-    },
-    {
-      "elapsed_sec": 125.000529125,
-      "heap_alloc_mb": 25.164093017578125,
-      "sys_mb": 65.07935333251953,
-      "num_gc": 112,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.0005910501969456207
-    },
-    {
-      "elapsed_sec": 130.001036125,
-      "heap_alloc_mb": 29.71778106689453,
-      "sys_mb": 65.07935333251953,
-      "num_gc": 114,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.00058630437831026
-    },
-    {
-      "elapsed_sec": 135.000624083,
-      "heap_alloc_mb": 30.673362731933594,
-      "sys_mb": 65.07935333251953,
-      "num_gc": 116,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.0005785996559660986
-    },
-    {
-      "elapsed_sec": 140.000810208,
-      "heap_alloc_mb": 30.013648986816406,
-      "sys_mb": 69.07935333251953,
-      "num_gc": 118,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.0005700006371140442
-    },
-    {
-      "elapsed_sec": 145.000889833,
-      "heap_alloc_mb": 47.11772155761719,
-      "sys_mb": 69.07935333251953,
-      "num_gc": 119,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0005673277654626
-    },
-    {
-      "elapsed_sec": 150.000935416,
-      "heap_alloc_mb": 40.48223114013672,
-      "sys_mb": 69.07935333251953,
-      "num_gc": 121,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.0005543103194779978
-    },
-    {
-      "elapsed_sec": 155.000756416,
-      "heap_alloc_mb": 34.24883270263672,
-      "sys_mb": 73.32935333251953,
-      "num_gc": 123,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.0005448856720925229
-    },
-    {
-      "elapsed_sec": 160.001068875,
-      "heap_alloc_mb": 51.18218994140625,
-      "sys_mb": 73.32935333251953,
-      "num_gc": 124,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0005399336278784887
-    },
-    {
-      "elapsed_sec": 165.000853458,
-      "heap_alloc_mb": 42.024452209472656,
-      "sys_mb": 73.32935333251953,
-      "num_gc": 126,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.000541426848998397
-    },
-    {
-      "elapsed_sec": 170.001327375,
-      "heap_alloc_mb": 34.433265686035156,
-      "sys_mb": 77.3947982788086,
-      "num_gc": 128,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0005382291902620549
-    },
-    {
-      "elapsed_sec": 175.000948125,
-      "heap_alloc_mb": 50.622596740722656,
-      "sys_mb": 77.3947982788086,
-      "num_gc": 129,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0005356531816112167
-    },
-    {
-      "elapsed_sec": 180.00085775,
-      "heap_alloc_mb": 40.66718292236328,
-      "sys_mb": 77.4572982788086,
-      "num_gc": 131,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0005281341984875946
-    },
-    {
-      "elapsed_sec": 185.000584958,
-      "heap_alloc_mb": 33.64924621582031,
-      "sys_mb": 81.4572982788086,
-      "num_gc": 133,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0005249193959738969
-    },
-    {
-      "elapsed_sec": 190.000939916,
-      "heap_alloc_mb": 47.16118621826172,
-      "sys_mb": 81.5197982788086,
-      "num_gc": 134,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.0005218064259387531
-    },
-    {
-      "elapsed_sec": 195.000327625,
-      "heap_alloc_mb": 39.101524353027344,
-      "sys_mb": 81.5822982788086,
-      "num_gc": 136,
-      "num_goroutine": 201,
-      "gc_cpu_fraction": 0.0005153181141656787
-    },
-    {
-      "elapsed_sec": 200.001060333,
-      "heap_alloc_mb": 56.3609619140625,
-      "sys_mb": 81.5822982788086,
-      "num_gc": 137,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0005159317311502188
-    },
-    {
-      "elapsed_sec": 205.000585333,
-      "heap_alloc_mb": 37.54033660888672,
-      "sys_mb": 85.6135482788086,
-      "num_gc": 139,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.000508028387423426
-    },
-    {
-      "elapsed_sec": 210.001106625,
-      "heap_alloc_mb": 47.655662536621094,
-      "sys_mb": 85.6135482788086,
-      "num_gc": 140,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.0005075949311006663
-    },
-    {
-      "elapsed_sec": 215.000866958,
-      "heap_alloc_mb": 59.54041290283203,
-      "sys_mb": 85.8635482788086,
-      "num_gc": 141,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0005048634200573942
-    },
-    {
-      "elapsed_sec": 220.000642,
-      "heap_alloc_mb": 67.56813049316406,
-      "sys_mb": 89.8635482788086,
-      "num_gc": 142,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0005016649407949083
-    },
-    {
-      "elapsed_sec": 225.0009285,
-      "heap_alloc_mb": 47.199310302734375,
-      "sys_mb": 89.8635482788086,
-      "num_gc": 144,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0004922862952650945
-    },
-    {
-      "elapsed_sec": 230.001206125,
-      "heap_alloc_mb": 53.864051818847656,
-      "sys_mb": 94.1135482788086,
-      "num_gc": 145,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0004895889905639307
-    },
-    {
-      "elapsed_sec": 235.000433541,
-      "heap_alloc_mb": 60.798614501953125,
-      "sys_mb": 94.1135482788086,
-      "num_gc": 146,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.00048582019866085646
-    },
-    {
-      "elapsed_sec": 240.000915833,
-      "heap_alloc_mb": 67.31332397460938,
-      "sys_mb": 98.1135482788086,
-      "num_gc": 147,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0004821268655384392
-    },
-    {
-      "elapsed_sec": 245.000268166,
-      "heap_alloc_mb": 72.05413055419922,
-      "sys_mb": 98.1135482788086,
-      "num_gc": 148,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.0004791595750601507
-    },
-    {
-      "elapsed_sec": 250.000943583,
-      "heap_alloc_mb": 75.662841796875,
-      "sys_mb": 98.3635482788086,
-      "num_gc": 149,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.0004750213425285944
-    },
-    {
-      "elapsed_sec": 255.001056333,
-      "heap_alloc_mb": 80.42202758789062,
-      "sys_mb": 102.3635482788086,
-      "num_gc": 150,
-      "num_goroutine": 200,
-      "gc_cpu_fraction": 0.00047183778433626777
-    },
-    {
-      "elapsed_sec": 260.001117583,
-      "heap_alloc_mb": 46.37303924560547,
-      "sys_mb": 106.3635482788086,
-      "num_gc": 152,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.00046329676589909423
-    },
-    {
-      "elapsed_sec": 265.000852125,
-      "heap_alloc_mb": 49.44396209716797,
-      "sys_mb": 106.3635482788086,
-      "num_gc": 153,
-      "num_goroutine": 190,
-      "gc_cpu_fraction": 0.00046022674308539746
-    },
-    {
-      "elapsed_sec": 270.001139416,
-      "heap_alloc_mb": 47.51593780517578,
-      "sys_mb": 110.4260482788086,
-      "num_gc": 154,
-      "num_goroutine": 200,
-      "gc_cpu_fraction": 0.0004572507576695774
-    },
-    {
-      "elapsed_sec": 275.000721041,
-      "heap_alloc_mb": 49.42582702636719,
-      "sys_mb": 110.4885482788086,
-      "num_gc": 155,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.00045456557634016936
-    },
-    {
-      "elapsed_sec": 280.000985291,
-      "heap_alloc_mb": 87.96231079101562,
-      "sys_mb": 110.5510482788086,
-      "num_gc": 155,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.00045456557634016936
-    },
-    {
-      "elapsed_sec": 285.000402541,
-      "heap_alloc_mb": 85.97572326660156,
-      "sys_mb": 110.5510482788086,
-      "num_gc": 156,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00044970139557581694
-    },
-    {
-      "elapsed_sec": 290.000993208,
-      "heap_alloc_mb": 85.14586639404297,
-      "sys_mb": 110.5510482788086,
-      "num_gc": 157,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0004469233147755055
-    },
-    {
-      "elapsed_sec": 295.00017925,
-      "heap_alloc_mb": 82.59967803955078,
-      "sys_mb": 114.5510482788086,
-      "num_gc": 158,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.00044451647347311347
-    },
-    {
-      "elapsed_sec": 300.001753875,
-      "heap_alloc_mb": 81.0557632446289,
-      "sys_mb": 114.5510482788086,
-      "num_gc": 159,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.0004421111461145979
-    },
-    {
-      "elapsed_sec": 305.001156041,
-      "heap_alloc_mb": 79.9696273803711,
-      "sys_mb": 114.5510482788086,
-      "num_gc": 160,
-      "num_goroutine": 200,
-      "gc_cpu_fraction": 0.00044067048917007564
-    },
-    {
-      "elapsed_sec": 310.001312583,
-      "heap_alloc_mb": 79.14480590820312,
-      "sys_mb": 114.5510482788086,
-      "num_gc": 161,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.00043845524995641486
-    },
-    {
-      "elapsed_sec": 315.001158708,
-      "heap_alloc_mb": 77.3998031616211,
-      "sys_mb": 114.8479232788086,
-      "num_gc": 162,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.0004357486343018185
-    },
-    {
-      "elapsed_sec": 320.000953208,
-      "heap_alloc_mb": 73.46688842773438,
-      "sys_mb": 118.8479232788086,
-      "num_gc": 163,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.0004323230787206457
-    },
-    {
-      "elapsed_sec": 325.001053666,
-      "heap_alloc_mb": 70.21847534179688,
-      "sys_mb": 122.8479232788086,
-      "num_gc": 164,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.0004305036519387132
-    },
-    {
-      "elapsed_sec": 330.000421875,
-      "heap_alloc_mb": 66.95948791503906,
-      "sys_mb": 122.8479232788086,
-      "num_gc": 165,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.0004335353202984139
-    },
-    {
-      "elapsed_sec": 335.001029708,
-      "heap_alloc_mb": 62.93296813964844,
-      "sys_mb": 122.8479232788086,
-      "num_gc": 166,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.000429703027087912
-    },
-    {
-      "elapsed_sec": 340.000914791,
-      "heap_alloc_mb": 56.99335479736328,
-      "sys_mb": 122.8479232788086,
-      "num_gc": 167,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.0004260868633745579
-    },
-    {
-      "elapsed_sec": 345.000610458,
-      "heap_alloc_mb": 96.84648895263672,
-      "sys_mb": 122.8479232788086,
-      "num_gc": 167,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0004260868633745579
-    },
-    {
-      "elapsed_sec": 350.001234125,
-      "heap_alloc_mb": 91.2064208984375,
-      "sys_mb": 126.8479232788086,
-      "num_gc": 168,
-      "num_goroutine": 189,
-      "gc_cpu_fraction": 0.0004240902458087455
-    },
-    {
-      "elapsed_sec": 355.001215708,
-      "heap_alloc_mb": 86.03922271728516,
-      "sys_mb": 130.8479232788086,
-      "num_gc": 169,
-      "num_goroutine": 190,
-      "gc_cpu_fraction": 0.0004235295276989014
-    },
-    {
-      "elapsed_sec": 360.000479875,
-      "heap_alloc_mb": 74.83805847167969,
-      "sys_mb": 130.8479232788086,
+      "elapsed_sec": 5.0018965,
+      "heap_alloc_mb": 53.154380798339844,
+      "sys_mb": 110.3655014038086,
       "num_gc": 170,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.00042172146846732777
+      "num_goroutine": 157,
+      "gc_cpu_fraction": 0.0030889522445965304
     },
     {
-      "elapsed_sec": 365.001221291,
-      "heap_alloc_mb": 68.64347076416016,
-      "sys_mb": 134.8479232788086,
+      "elapsed_sec": 10.000600625,
+      "heap_alloc_mb": 48.00206756591797,
+      "sys_mb": 110.6155014038086,
       "num_gc": 171,
-      "num_goroutine": 189,
-      "gc_cpu_fraction": 0.0004178985527440509
+      "num_goroutine": 168,
+      "gc_cpu_fraction": 0.002554288880306414
     },
     {
-      "elapsed_sec": 370.001336416,
-      "heap_alloc_mb": 107.31928253173828,
-      "sys_mb": 134.8479232788086,
-      "num_gc": 171,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0004178985527440509
-    },
-    {
-      "elapsed_sec": 375.000955041,
-      "heap_alloc_mb": 97.26502227783203,
-      "sys_mb": 135.0979232788086,
+      "elapsed_sec": 15.001613125,
+      "heap_alloc_mb": 45.49241638183594,
+      "sys_mb": 110.6155014038086,
       "num_gc": 172,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0004155466871877174
+      "num_goroutine": 180,
+      "gc_cpu_fraction": 0.002217309200861094
     },
     {
-      "elapsed_sec": 380.001814875,
-      "heap_alloc_mb": 85.55747985839844,
-      "sys_mb": 139.1604232788086,
+      "elapsed_sec": 20.001708333,
+      "heap_alloc_mb": 79.1446762084961,
+      "sys_mb": 110.6155014038086,
+      "num_gc": 172,
+      "num_goroutine": 190,
+      "gc_cpu_fraction": 0.002217309200861094
+    },
+    {
+      "elapsed_sec": 25.000420916,
+      "heap_alloc_mb": 77.8958740234375,
+      "sys_mb": 110.6155014038086,
       "num_gc": 173,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.000413211979935716
+      "num_goroutine": 200,
+      "gc_cpu_fraction": 0.0019493688288226296
     },
     {
-      "elapsed_sec": 385.00054475,
-      "heap_alloc_mb": 74.04161071777344,
-      "sys_mb": 143.53836822509766,
+      "elapsed_sec": 30.002311125,
+      "heap_alloc_mb": 79.95531463623047,
+      "sys_mb": 110.6155014038086,
       "num_gc": 174,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.0004104064346535331
+      "num_goroutine": 201,
+      "gc_cpu_fraction": 0.0017512496606404792
     },
     {
-      "elapsed_sec": 390.001418041,
-      "heap_alloc_mb": 114.41172790527344,
-      "sys_mb": 143.60086822509766,
-      "num_gc": 174,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0004104064346535331
-    },
-    {
-      "elapsed_sec": 395.001617166,
-      "heap_alloc_mb": 96.96727752685547,
-      "sys_mb": 147.60086822509766,
+      "elapsed_sec": 35.002217458,
+      "heap_alloc_mb": 81.69747924804688,
+      "sys_mb": 110.6155014038086,
       "num_gc": 175,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.0004092492508541207
+      "num_goroutine": 200,
+      "gc_cpu_fraction": 0.0016219303130850537
     },
     {
-      "elapsed_sec": 400.001544041,
-      "heap_alloc_mb": 83.00399780273438,
-      "sys_mb": 147.60086822509766,
+      "elapsed_sec": 40.001566958,
+      "heap_alloc_mb": 81.25354766845703,
+      "sys_mb": 110.6155014038086,
       "num_gc": 176,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.00040757403642093046
-    },
-    {
-      "elapsed_sec": 405.000953666,
-      "heap_alloc_mb": 69.27806091308594,
-      "sys_mb": 147.60086822509766,
-      "num_gc": 177,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.00040404020099457584
-    },
-    {
-      "elapsed_sec": 410.000234333,
-      "heap_alloc_mb": 107.38823699951172,
-      "sys_mb": 147.60086822509766,
-      "num_gc": 177,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00040404020099457584
-    },
-    {
-      "elapsed_sec": 415.000891708,
-      "heap_alloc_mb": 92.28646850585938,
-      "sys_mb": 147.60086822509766,
-      "num_gc": 178,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00040112433181292164
-    },
-    {
-      "elapsed_sec": 420.000390708,
-      "heap_alloc_mb": 75.6902847290039,
-      "sys_mb": 151.60086822509766,
-      "num_gc": 179,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.0003986801849694996
-    },
-    {
-      "elapsed_sec": 425.001056125,
-      "heap_alloc_mb": 116.76197052001953,
-      "sys_mb": 151.60086822509766,
-      "num_gc": 179,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0003986801849694996
-    },
-    {
-      "elapsed_sec": 430.001154958,
-      "heap_alloc_mb": 97.40850830078125,
-      "sys_mb": 151.60086822509766,
-      "num_gc": 180,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.000394859987768272
-    },
-    {
-      "elapsed_sec": 435.000690708,
-      "heap_alloc_mb": 78.55870819091797,
-      "sys_mb": 159.60086822509766,
-      "num_gc": 181,
-      "num_goroutine": 188,
-      "gc_cpu_fraction": 0.0003914108504703437
-    },
-    {
-      "elapsed_sec": 440.000867625,
-      "heap_alloc_mb": 117.605712890625,
-      "sys_mb": 159.60086822509766,
-      "num_gc": 181,
-      "num_goroutine": 190,
-      "gc_cpu_fraction": 0.0003914108504703437
-    },
-    {
-      "elapsed_sec": 445.000428458,
-      "heap_alloc_mb": 95.23062896728516,
-      "sys_mb": 159.60086822509766,
-      "num_gc": 182,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.00038791753948737507
-    },
-    {
-      "elapsed_sec": 450.000738541,
-      "heap_alloc_mb": 134.8655242919922,
-      "sys_mb": 159.60086822509766,
-      "num_gc": 182,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.00038791753948737507
-    },
-    {
-      "elapsed_sec": 455.001103625,
-      "heap_alloc_mb": 113.53437042236328,
-      "sys_mb": 163.60086822509766,
-      "num_gc": 183,
-      "num_goroutine": 189,
-      "gc_cpu_fraction": 0.00038412462383677457
-    },
-    {
-      "elapsed_sec": 460.001113625,
-      "heap_alloc_mb": 88.04719543457031,
-      "sys_mb": 163.60086822509766,
-      "num_gc": 184,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.00038741224948439057
-    },
-    {
-      "elapsed_sec": 465.001130916,
-      "heap_alloc_mb": 128.16382598876953,
-      "sys_mb": 163.60086822509766,
-      "num_gc": 184,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.00038741224948439057
-    },
-    {
-      "elapsed_sec": 470.001279666,
-      "heap_alloc_mb": 102.5011978149414,
-      "sys_mb": 163.60086822509766,
-      "num_gc": 185,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.00038888190209097716
-    },
-    {
-      "elapsed_sec": 475.000614125,
-      "heap_alloc_mb": 142.2935028076172,
-      "sys_mb": 163.60086822509766,
-      "num_gc": 185,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.00038888190209097716
-    },
-    {
-      "elapsed_sec": 480.000840041,
-      "heap_alloc_mb": 117.07218933105469,
-      "sys_mb": 167.66336822509766,
-      "num_gc": 186,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.0003852163942592986
-    },
-    {
-      "elapsed_sec": 485.000423833,
-      "heap_alloc_mb": 89.0589599609375,
-      "sys_mb": 171.79618072509766,
-      "num_gc": 187,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0003820261770494047
-    },
-    {
-      "elapsed_sec": 490.000968708,
-      "heap_alloc_mb": 128.60155487060547,
-      "sys_mb": 171.79618072509766,
-      "num_gc": 187,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0003820261770494047
-    },
-    {
-      "elapsed_sec": 495.000842416,
-      "heap_alloc_mb": 99.23469543457031,
-      "sys_mb": 175.85868072509766,
-      "num_gc": 188,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.00038042391616076185
-    },
-    {
-      "elapsed_sec": 500.001884083,
-      "heap_alloc_mb": 138.4955291748047,
-      "sys_mb": 175.85868072509766,
-      "num_gc": 188,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.00038042391616076185
-    },
-    {
-      "elapsed_sec": 505.000921875,
-      "heap_alloc_mb": 110.56143188476562,
-      "sys_mb": 175.85868072509766,
-      "num_gc": 189,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.00038028687246597243
-    },
-    {
-      "elapsed_sec": 510.001087708,
-      "heap_alloc_mb": 148.34424591064453,
-      "sys_mb": 175.85868072509766,
-      "num_gc": 189,
-      "num_goroutine": 202,
-      "gc_cpu_fraction": 0.00038028687246597243
-    },
-    {
-      "elapsed_sec": 515.000347833,
-      "heap_alloc_mb": 119.73929595947266,
-      "sys_mb": 179.85868072509766,
-      "num_gc": 190,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.00037768438153647894
-    },
-    {
-      "elapsed_sec": 520.001025083,
-      "heap_alloc_mb": 86.02401733398438,
-      "sys_mb": 179.85868072509766,
-      "num_gc": 191,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00037503630505790524
-    },
-    {
-      "elapsed_sec": 525.001158333,
-      "heap_alloc_mb": 127.09832000732422,
-      "sys_mb": 179.85868072509766,
-      "num_gc": 191,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00037503630505790524
-    },
-    {
-      "elapsed_sec": 530.001007041,
-      "heap_alloc_mb": 96.53060913085938,
-      "sys_mb": 183.85868072509766,
-      "num_gc": 192,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.00037217758210069714
-    },
-    {
-      "elapsed_sec": 535.001123083,
-      "heap_alloc_mb": 137.73981475830078,
-      "sys_mb": 183.85868072509766,
-      "num_gc": 192,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.00037217758210069714
-    },
-    {
-      "elapsed_sec": 540.001897416,
-      "heap_alloc_mb": 104.139404296875,
-      "sys_mb": 187.85868072509766,
-      "num_gc": 193,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.0003705104537111526
-    },
-    {
-      "elapsed_sec": 545.000953583,
-      "heap_alloc_mb": 145.11720275878906,
-      "sys_mb": 187.85868072509766,
-      "num_gc": 193,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0003705104537111526
-    },
-    {
-      "elapsed_sec": 550.001447708,
-      "heap_alloc_mb": 109.33465576171875,
-      "sys_mb": 187.85868072509766,
-      "num_gc": 194,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.00036840189991252224
-    },
-    {
-      "elapsed_sec": 555.00086325,
-      "heap_alloc_mb": 152.48822784423828,
-      "sys_mb": 187.85868072509766,
-      "num_gc": 194,
-      "num_goroutine": 190,
-      "gc_cpu_fraction": 0.00036840189991252224
-    },
-    {
-      "elapsed_sec": 560.000938791,
-      "heap_alloc_mb": 117.05558776855469,
-      "sys_mb": 187.85868072509766,
-      "num_gc": 195,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0003660606334788134
-    },
-    {
-      "elapsed_sec": 565.000822833,
-      "heap_alloc_mb": 156.50348663330078,
-      "sys_mb": 187.85868072509766,
-      "num_gc": 195,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0003660606334788134
-    },
-    {
-      "elapsed_sec": 570.000314833,
-      "heap_alloc_mb": 120.60055541992188,
-      "sys_mb": 191.85868072509766,
-      "num_gc": 196,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.00036348647729126694
-    },
-    {
-      "elapsed_sec": 575.000558125,
-      "heap_alloc_mb": 160.86487579345703,
-      "sys_mb": 191.85868072509766,
-      "num_gc": 196,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.00036348647729126694
-    },
-    {
-      "elapsed_sec": 580.001307,
-      "heap_alloc_mb": 124.60779571533203,
-      "sys_mb": 195.92118072509766,
-      "num_gc": 197,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.00036118582703196557
-    },
-    {
-      "elapsed_sec": 585.000916041,
-      "heap_alloc_mb": 164.79962158203125,
-      "sys_mb": 195.92118072509766,
-      "num_gc": 197,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.00036118582703196557
-    },
-    {
-      "elapsed_sec": 590.00095175,
-      "heap_alloc_mb": 127.08592224121094,
-      "sys_mb": 195.98368072509766,
-      "num_gc": 198,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.00035963926190816516
-    },
-    {
-      "elapsed_sec": 595.000308875,
-      "heap_alloc_mb": 167.0909423828125,
-      "sys_mb": 195.98368072509766,
-      "num_gc": 198,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.00035963926190816516
-    },
-    {
-      "elapsed_sec": 600.001142041,
-      "heap_alloc_mb": 127.54824829101562,
-      "sys_mb": 196.04618072509766,
-      "num_gc": 199,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00035723009620124363
-    },
-    {
-      "elapsed_sec": 605.001052958,
-      "heap_alloc_mb": 168.13204956054688,
-      "sys_mb": 196.04618072509766,
-      "num_gc": 199,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.00035723009620124363
-    },
-    {
-      "elapsed_sec": 610.001206916,
-      "heap_alloc_mb": 127.45136260986328,
-      "sys_mb": 204.04618072509766,
-      "num_gc": 200,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.0003560559026702724
-    },
-    {
-      "elapsed_sec": 615.000344375,
-      "heap_alloc_mb": 170.06554412841797,
-      "sys_mb": 204.04618072509766,
-      "num_gc": 200,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.0003560559026702724
-    },
-    {
-      "elapsed_sec": 620.001067583,
-      "heap_alloc_mb": 128.94737243652344,
-      "sys_mb": 204.04618072509766,
-      "num_gc": 201,
-      "num_goroutine": 190,
-      "gc_cpu_fraction": 0.0003534748089852933
-    },
-    {
-      "elapsed_sec": 625.000901375,
-      "heap_alloc_mb": 168.96142578125,
-      "sys_mb": 204.04618072509766,
-      "num_gc": 201,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0003534748089852933
-    },
-    {
-      "elapsed_sec": 630.001144458,
-      "heap_alloc_mb": 122.82052612304688,
-      "sys_mb": 212.11162567138672,
-      "num_gc": 202,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.0003511695278824797
-    },
-    {
-      "elapsed_sec": 635.001050125,
-      "heap_alloc_mb": 162.98822021484375,
-      "sys_mb": 212.11162567138672,
-      "num_gc": 202,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.0003511695278824797
-    },
-    {
-      "elapsed_sec": 640.00089125,
-      "heap_alloc_mb": 118.3821792602539,
-      "sys_mb": 212.11162567138672,
-      "num_gc": 203,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00034985835197859664
-    },
-    {
-      "elapsed_sec": 645.000948041,
-      "heap_alloc_mb": 158.0667724609375,
-      "sys_mb": 212.11162567138672,
-      "num_gc": 203,
-      "num_goroutine": 201,
-      "gc_cpu_fraction": 0.00034985835197859664
-    },
-    {
-      "elapsed_sec": 650.001178791,
-      "heap_alloc_mb": 110.9668960571289,
-      "sys_mb": 212.11162567138672,
-      "num_gc": 204,
-      "num_goroutine": 202,
-      "gc_cpu_fraction": 0.0003497573792405903
-    },
-    {
-      "elapsed_sec": 655.000466291,
-      "heap_alloc_mb": 150.73030853271484,
-      "sys_mb": 212.11162567138672,
-      "num_gc": 204,
       "num_goroutine": 203,
-      "gc_cpu_fraction": 0.0003497573792405903
+      "gc_cpu_fraction": 0.001505503462919054
     },
     {
-      "elapsed_sec": 660.000980416,
-      "heap_alloc_mb": 103.98020935058594,
-      "sys_mb": 216.11162567138672,
-      "num_gc": 205,
-      "num_goroutine": 200,
-      "gc_cpu_fraction": 0.00034856584250112557
-    },
-    {
-      "elapsed_sec": 665.000248041,
-      "heap_alloc_mb": 144.54071807861328,
-      "sys_mb": 216.11162567138672,
-      "num_gc": 205,
-      "num_goroutine": 201,
-      "gc_cpu_fraction": 0.00034856584250112557
-    },
-    {
-      "elapsed_sec": 670.00097925,
-      "heap_alloc_mb": 186.5375518798828,
-      "sys_mb": 216.11162567138672,
-      "num_gc": 205,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.00034856584250112557
-    },
-    {
-      "elapsed_sec": 675.001084416,
-      "heap_alloc_mb": 135.11949920654297,
-      "sys_mb": 220.61162567138672,
-      "num_gc": 206,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.0003476786077140357
-    },
-    {
-      "elapsed_sec": 680.001402625,
-      "heap_alloc_mb": 176.22521209716797,
-      "sys_mb": 220.61162567138672,
-      "num_gc": 206,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0003476786077140357
-    },
-    {
-      "elapsed_sec": 685.000731708,
-      "heap_alloc_mb": 127.35237121582031,
-      "sys_mb": 224.67412567138672,
-      "num_gc": 207,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.0003470029117366305
-    },
-    {
-      "elapsed_sec": 690.00106825,
-      "heap_alloc_mb": 166.8881607055664,
-      "sys_mb": 224.67412567138672,
-      "num_gc": 207,
-      "num_goroutine": 188,
-      "gc_cpu_fraction": 0.0003470029117366305
-    },
-    {
-      "elapsed_sec": 695.000940041,
-      "heap_alloc_mb": 116.51383209228516,
-      "sys_mb": 228.73662567138672,
-      "num_gc": 208,
-      "num_goroutine": 187,
-      "gc_cpu_fraction": 0.0003447790414685722
-    },
-    {
-      "elapsed_sec": 700.000865625,
-      "heap_alloc_mb": 154.6216049194336,
-      "sys_mb": 228.73662567138672,
-      "num_gc": 208,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.0003447790414685722
-    },
-    {
-      "elapsed_sec": 705.001088958,
-      "heap_alloc_mb": 193.75176239013672,
-      "sys_mb": 228.73662567138672,
-      "num_gc": 208,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0003447790414685722
-    },
-    {
-      "elapsed_sec": 710.001113791,
-      "heap_alloc_mb": 138.88909149169922,
-      "sys_mb": 228.79912567138672,
-      "num_gc": 209,
-      "num_goroutine": 197,
-      "gc_cpu_fraction": 0.0003429406845702787
-    },
-    {
-      "elapsed_sec": 715.000763416,
-      "heap_alloc_mb": 181.6749496459961,
-      "sys_mb": 228.79912567138672,
-      "num_gc": 209,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0003429406845702787
-    },
-    {
-      "elapsed_sec": 720.001078333,
-      "heap_alloc_mb": 125.3617172241211,
-      "sys_mb": 232.79912567138672,
-      "num_gc": 210,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00034135204476024944
-    },
-    {
-      "elapsed_sec": 725.000878291,
-      "heap_alloc_mb": 166.78105926513672,
-      "sys_mb": 232.79912567138672,
-      "num_gc": 210,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.00034135204476024944
-    },
-    {
-      "elapsed_sec": 730.000991125,
-      "heap_alloc_mb": 204.76860809326172,
-      "sys_mb": 232.79912567138672,
-      "num_gc": 210,
-      "num_goroutine": 202,
-      "gc_cpu_fraction": 0.00034135204476024944
-    },
-    {
-      "elapsed_sec": 735.001475916,
-      "heap_alloc_mb": 147.06138610839844,
-      "sys_mb": 237.04912567138672,
-      "num_gc": 211,
+      "elapsed_sec": 45.002037583,
+      "heap_alloc_mb": 80.8846206665039,
+      "sys_mb": 110.6155014038086,
+      "num_gc": 177,
       "num_goroutine": 207,
-      "gc_cpu_fraction": 0.00034133859544140685
+      "gc_cpu_fraction": 0.0014049284215947669
     },
     {
-      "elapsed_sec": 740.000451333,
-      "heap_alloc_mb": 190.00706481933594,
-      "sys_mb": 237.04912567138672,
-      "num_gc": 211,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00034133859544140685
+      "elapsed_sec": 50.000784833,
+      "heap_alloc_mb": 78.82122802734375,
+      "sys_mb": 110.6155014038086,
+      "num_gc": 178,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.0013130518185424222
     },
     {
-      "elapsed_sec": 745.001068458,
-      "heap_alloc_mb": 135.7887954711914,
-      "sys_mb": 241.29912567138672,
-      "num_gc": 212,
-      "num_goroutine": 187,
-      "gc_cpu_fraction": 0.00033992067132633454
+      "elapsed_sec": 55.0024415,
+      "heap_alloc_mb": 78.61528778076172,
+      "sys_mb": 110.6155014038086,
+      "num_gc": 179,
+      "num_goroutine": 219,
+      "gc_cpu_fraction": 0.0012545989405441328
     },
     {
-      "elapsed_sec": 750.000303875,
-      "heap_alloc_mb": 174.0917510986328,
-      "sys_mb": 241.29912567138672,
-      "num_gc": 212,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.00033992067132633454
+      "elapsed_sec": 60.001128416,
+      "heap_alloc_mb": 78.8944320678711,
+      "sys_mb": 110.6155014038086,
+      "num_gc": 180,
+      "num_goroutine": 218,
+      "gc_cpu_fraction": 0.0011824258938219645
     },
     {
-      "elapsed_sec": 755.00096375,
-      "heap_alloc_mb": 213.0870132446289,
-      "sys_mb": 241.29912567138672,
-      "num_gc": 212,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.00033992067132633454
+      "elapsed_sec": 65.00069525,
+      "heap_alloc_mb": 81.77808380126953,
+      "sys_mb": 110.6155014038086,
+      "num_gc": 181,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0011293525749737062
     },
     {
-      "elapsed_sec": 760.001248541,
-      "heap_alloc_mb": 150.35903930664062,
-      "sys_mb": 249.40459442138672,
-      "num_gc": 213,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.00033749818016423524
+      "elapsed_sec": 70.002411916,
+      "heap_alloc_mb": 79.95909118652344,
+      "sys_mb": 114.6155014038086,
+      "num_gc": 182,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0010846805330494355
     },
     {
-      "elapsed_sec": 765.000986291,
-      "heap_alloc_mb": 190.5648422241211,
-      "sys_mb": 249.40459442138672,
-      "num_gc": 213,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.00033749818016423524
+      "elapsed_sec": 75.002225666,
+      "heap_alloc_mb": 75.33576965332031,
+      "sys_mb": 118.7405014038086,
+      "num_gc": 183,
+      "num_goroutine": 216,
+      "gc_cpu_fraction": 0.0010501341981301521
     },
     {
-      "elapsed_sec": 770.00107075,
-      "heap_alloc_mb": 124.56438446044922,
-      "sys_mb": 249.40459442138672,
-      "num_gc": 214,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0003349206275314142
+      "elapsed_sec": 80.00243,
+      "heap_alloc_mb": 72.83573913574219,
+      "sys_mb": 118.7405014038086,
+      "num_gc": 184,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.001013106582990742
     },
     {
-      "elapsed_sec": 775.000365333,
-      "heap_alloc_mb": 164.9441375732422,
-      "sys_mb": 249.40459442138672,
-      "num_gc": 214,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0003349206275314142
+      "elapsed_sec": 85.028091708,
+      "heap_alloc_mb": 69.75682830810547,
+      "sys_mb": 118.8030014038086,
+      "num_gc": 185,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.0009707777122012602
     },
     {
-      "elapsed_sec": 780.00086225,
-      "heap_alloc_mb": 204.20498657226562,
-      "sys_mb": 249.40459442138672,
-      "num_gc": 214,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.0003349206275314142
+      "elapsed_sec": 90.00051425,
+      "heap_alloc_mb": 67.25127410888672,
+      "sys_mb": 118.8498764038086,
+      "num_gc": 186,
+      "num_goroutine": 205,
+      "gc_cpu_fraction": 0.0009418095315185661
     },
     {
-      "elapsed_sec": 785.000819458,
-      "heap_alloc_mb": 138.14705657958984,
-      "sys_mb": 257.7170944213867,
-      "num_gc": 215,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.000332790848193301
+      "elapsed_sec": 95.001724208,
+      "heap_alloc_mb": 65.33997344970703,
+      "sys_mb": 118.8498764038086,
+      "num_gc": 187,
+      "num_goroutine": 200,
+      "gc_cpu_fraction": 0.0009164231380387016
     },
     {
-      "elapsed_sec": 790.001325666,
-      "heap_alloc_mb": 177.79766082763672,
-      "sys_mb": 257.7170944213867,
-      "num_gc": 215,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.000332790848193301
+      "elapsed_sec": 100.00057525,
+      "heap_alloc_mb": 58.102874755859375,
+      "sys_mb": 118.8498764038086,
+      "num_gc": 188,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.000891395369342052
     },
     {
-      "elapsed_sec": 795.00129375,
-      "heap_alloc_mb": 218.63800048828125,
-      "sys_mb": 257.7170944213867,
-      "num_gc": 215,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.000332790848193301
+      "elapsed_sec": 105.002283375,
+      "heap_alloc_mb": 53.50249481201172,
+      "sys_mb": 122.8498764038086,
+      "num_gc": 189,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.0008726130658627944
     },
     {
-      "elapsed_sec": 800.001580333,
-      "heap_alloc_mb": 148.69176483154297,
-      "sys_mb": 261.7795944213867,
-      "num_gc": 216,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.00033095581724904016
+      "elapsed_sec": 110.001194458,
+      "heap_alloc_mb": 92.483154296875,
+      "sys_mb": 122.8498764038086,
+      "num_gc": 189,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.0008726130658627944
     },
     {
-      "elapsed_sec": 805.001213041,
-      "heap_alloc_mb": 189.13762664794922,
-      "sys_mb": 261.7795944213867,
-      "num_gc": 216,
-      "num_goroutine": 198,
-      "gc_cpu_fraction": 0.00033095581724904016
+      "elapsed_sec": 115.002282,
+      "heap_alloc_mb": 86.73672485351562,
+      "sys_mb": 122.8498764038086,
+      "num_gc": 190,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.000849452939598319
     },
     {
-      "elapsed_sec": 810.000452666,
-      "heap_alloc_mb": 226.84003448486328,
-      "sys_mb": 261.8420944213867,
-      "num_gc": 216,
+      "elapsed_sec": 120.002768875,
+      "heap_alloc_mb": 79.1634521484375,
+      "sys_mb": 122.8498764038086,
+      "num_gc": 191,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.0008244842930199273
+    },
+    {
+      "elapsed_sec": 125.001411375,
+      "heap_alloc_mb": 74.47692108154297,
+      "sys_mb": 126.8498764038086,
+      "num_gc": 192,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.000802957331343094
+    },
+    {
+      "elapsed_sec": 130.001325333,
+      "heap_alloc_mb": 63.80841827392578,
+      "sys_mb": 126.8498764038086,
+      "num_gc": 193,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.0007784181549767978
+    },
+    {
+      "elapsed_sec": 135.000208083,
+      "heap_alloc_mb": 99.91011810302734,
+      "sys_mb": 126.8498764038086,
+      "num_gc": 193,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.0007784181549767978
+    },
+    {
+      "elapsed_sec": 140.001284125,
+      "heap_alloc_mb": 89.7465591430664,
+      "sys_mb": 130.8498764038086,
+      "num_gc": 194,
       "num_goroutine": 204,
-      "gc_cpu_fraction": 0.00033095581724904016
+      "gc_cpu_fraction": 0.0007502157533311799
     },
     {
-      "elapsed_sec": 815.001536791,
-      "heap_alloc_mb": 157.77819061279297,
-      "sys_mb": 266.0920944213867,
+      "elapsed_sec": 145.001279333,
+      "heap_alloc_mb": 76.23082733154297,
+      "sys_mb": 130.8498764038086,
+      "num_gc": 195,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.000727222695878977
+    },
+    {
+      "elapsed_sec": 150.001338375,
+      "heap_alloc_mb": 64.88978576660156,
+      "sys_mb": 130.8498764038086,
+      "num_gc": 196,
+      "num_goroutine": 221,
+      "gc_cpu_fraction": 0.0007096650251454179
+    },
+    {
+      "elapsed_sec": 155.001242333,
+      "heap_alloc_mb": 59.87782287597656,
+      "sys_mb": 130.8498764038086,
+      "num_gc": 197,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0006930989964851737
+    },
+    {
+      "elapsed_sec": 160.001267375,
+      "heap_alloc_mb": 100.2799072265625,
+      "sys_mb": 130.8498764038086,
+      "num_gc": 197,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.0006930989964851737
+    },
+    {
+      "elapsed_sec": 165.000624958,
+      "heap_alloc_mb": 92.54863739013672,
+      "sys_mb": 130.8498764038086,
+      "num_gc": 198,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0006802358679573093
+    },
+    {
+      "elapsed_sec": 170.00147525,
+      "heap_alloc_mb": 86.65061950683594,
+      "sys_mb": 130.8498764038086,
+      "num_gc": 199,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0006639023501638122
+    },
+    {
+      "elapsed_sec": 175.0014035,
+      "heap_alloc_mb": 77.89544677734375,
+      "sys_mb": 130.8498764038086,
+      "num_gc": 200,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.0006500806848170353
+    },
+    {
+      "elapsed_sec": 180.001480958,
+      "heap_alloc_mb": 68.49137878417969,
+      "sys_mb": 138.8498764038086,
+      "num_gc": 201,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.0006346863059501413
+    },
+    {
+      "elapsed_sec": 185.001375958,
+      "heap_alloc_mb": 108.28238677978516,
+      "sys_mb": 138.8498764038086,
+      "num_gc": 201,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0006346863059501413
+    },
+    {
+      "elapsed_sec": 190.001580125,
+      "heap_alloc_mb": 94.96424102783203,
+      "sys_mb": 138.8498764038086,
+      "num_gc": 202,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.0006226994316721573
+    },
+    {
+      "elapsed_sec": 195.000624958,
+      "heap_alloc_mb": 81.64657592773438,
+      "sys_mb": 138.8498764038086,
+      "num_gc": 203,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.0006093540735633562
+    },
+    {
+      "elapsed_sec": 200.001801458,
+      "heap_alloc_mb": 68.40180206298828,
+      "sys_mb": 138.8498764038086,
+      "num_gc": 204,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.0005994373145243654
+    },
+    {
+      "elapsed_sec": 205.00040125,
+      "heap_alloc_mb": 107.82809448242188,
+      "sys_mb": 138.8498764038086,
+      "num_gc": 204,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.0005994373145243654
+    },
+    {
+      "elapsed_sec": 210.00133425,
+      "heap_alloc_mb": 94.09862518310547,
+      "sys_mb": 138.8498764038086,
+      "num_gc": 205,
+      "num_goroutine": 219,
+      "gc_cpu_fraction": 0.000588212371585581
+    },
+    {
+      "elapsed_sec": 215.001320041,
+      "heap_alloc_mb": 83.42656707763672,
+      "sys_mb": 138.8498764038086,
+      "num_gc": 206,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.000579068619292734
+    },
+    {
+      "elapsed_sec": 220.001576291,
+      "heap_alloc_mb": 69.4010009765625,
+      "sys_mb": 142.91629791259766,
+      "num_gc": 207,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.000576751487915668
+    },
+    {
+      "elapsed_sec": 225.001198833,
+      "heap_alloc_mb": 111.97222900390625,
+      "sys_mb": 142.91629791259766,
+      "num_gc": 207,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.000576751487915668
+    },
+    {
+      "elapsed_sec": 230.001556,
+      "heap_alloc_mb": 98.3770980834961,
+      "sys_mb": 142.91629791259766,
+      "num_gc": 208,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.0005677824941633662
+    },
+    {
+      "elapsed_sec": 235.000479208,
+      "heap_alloc_mb": 84.24353790283203,
+      "sys_mb": 143.16629791259766,
+      "num_gc": 209,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.0005580160189184121
+    },
+    {
+      "elapsed_sec": 240.001539,
+      "heap_alloc_mb": 67.70391082763672,
+      "sys_mb": 147.16629791259766,
+      "num_gc": 210,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0005562461469045394
+    },
+    {
+      "elapsed_sec": 245.001375,
+      "heap_alloc_mb": 106.26785278320312,
+      "sys_mb": 147.16629791259766,
+      "num_gc": 210,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.0005562461469045394
+    },
+    {
+      "elapsed_sec": 250.000429791,
+      "heap_alloc_mb": 89.43310546875,
+      "sys_mb": 147.29129791259766,
+      "num_gc": 211,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.0005483884626257795
+    },
+    {
+      "elapsed_sec": 255.0013875,
+      "heap_alloc_mb": 73.9194107055664,
+      "sys_mb": 151.29129791259766,
+      "num_gc": 212,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.0005376755098954258
+    },
+    {
+      "elapsed_sec": 260.000509083,
+      "heap_alloc_mb": 114.71019744873047,
+      "sys_mb": 151.29129791259766,
+      "num_gc": 212,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0005376755098954258
+    },
+    {
+      "elapsed_sec": 265.001286791,
+      "heap_alloc_mb": 99.45841217041016,
+      "sys_mb": 151.35379791259766,
+      "num_gc": 213,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0005316092840647561
+    },
+    {
+      "elapsed_sec": 270.001507875,
+      "heap_alloc_mb": 81.0391616821289,
+      "sys_mb": 151.35379791259766,
+      "num_gc": 214,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0005227065875908471
+    },
+    {
+      "elapsed_sec": 275.001216208,
+      "heap_alloc_mb": 67.42987060546875,
+      "sys_mb": 151.35379791259766,
+      "num_gc": 215,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.0005157065238267459
+    },
+    {
+      "elapsed_sec": 280.001231125,
+      "heap_alloc_mb": 104.86273193359375,
+      "sys_mb": 151.35379791259766,
+      "num_gc": 215,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.0005157065238267459
+    },
+    {
+      "elapsed_sec": 285.000476458,
+      "heap_alloc_mb": 88.00971221923828,
+      "sys_mb": 151.35379791259766,
+      "num_gc": 216,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.000506774617662044
+    },
+    {
+      "elapsed_sec": 290.001284,
+      "heap_alloc_mb": 71.8326416015625,
+      "sys_mb": 151.35379791259766,
       "num_gc": 217,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00032966293148375904
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.0004990668262104825
     },
     {
-      "elapsed_sec": 820.000461458,
-      "heap_alloc_mb": 198.01563262939453,
-      "sys_mb": 266.0920944213867,
+      "elapsed_sec": 295.000732833,
+      "heap_alloc_mb": 111.76020812988281,
+      "sys_mb": 151.35379791259766,
       "num_gc": 217,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.00032966293148375904
+      "num_goroutine": 205,
+      "gc_cpu_fraction": 0.0004990668262104825
     },
     {
-      "elapsed_sec": 825.000269083,
-      "heap_alloc_mb": 126.79975128173828,
-      "sys_mb": 266.0920944213867,
+      "elapsed_sec": 300.001340875,
+      "heap_alloc_mb": 90.8224868774414,
+      "sys_mb": 155.60379791259766,
       "num_gc": 218,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0003278746345171206
+      "num_goroutine": 203,
+      "gc_cpu_fraction": 0.0004905955097770165
     },
     {
-      "elapsed_sec": 830.00137325,
-      "heap_alloc_mb": 167.41063690185547,
-      "sys_mb": 266.0920944213867,
+      "elapsed_sec": 305.000662125,
+      "heap_alloc_mb": 129.07917022705078,
+      "sys_mb": 155.60379791259766,
       "num_gc": 218,
-      "num_goroutine": 187,
-      "gc_cpu_fraction": 0.0003278746345171206
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0004905955097770165
     },
     {
-      "elapsed_sec": 835.000687666,
-      "heap_alloc_mb": 205.1419677734375,
-      "sys_mb": 266.0920944213867,
-      "num_gc": 218,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0003278746345171206
-    },
-    {
-      "elapsed_sec": 840.001297916,
-      "heap_alloc_mb": 132.96564483642578,
-      "sys_mb": 270.3420944213867,
+      "elapsed_sec": 310.000520375,
+      "heap_alloc_mb": 106.20671081542969,
+      "sys_mb": 159.60379791259766,
       "num_gc": 219,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.00032467832125819215
+      "num_goroutine": 216,
+      "gc_cpu_fraction": 0.00048209750839780483
     },
     {
-      "elapsed_sec": 845.001747208,
-      "heap_alloc_mb": 173.50432586669922,
-      "sys_mb": 270.3420944213867,
-      "num_gc": 219,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.00032467832125819215
-    },
-    {
-      "elapsed_sec": 850.001204,
-      "heap_alloc_mb": 213.01302337646484,
-      "sys_mb": 270.3420944213867,
-      "num_gc": 219,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.00032467832125819215
-    },
-    {
-      "elapsed_sec": 855.001278083,
-      "heap_alloc_mb": 140.29888916015625,
-      "sys_mb": 274.6575393676758,
+      "elapsed_sec": 315.001267791,
+      "heap_alloc_mb": 84.68850708007812,
+      "sys_mb": 159.85379791259766,
       "num_gc": 220,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.00032491131795382315
+      "num_goroutine": 220,
+      "gc_cpu_fraction": 0.00047471880025935786
     },
     {
-      "elapsed_sec": 860.001336375,
-      "heap_alloc_mb": 179.3619842529297,
-      "sys_mb": 274.6575393676758,
+      "elapsed_sec": 320.001163541,
+      "heap_alloc_mb": 124.94587707519531,
+      "sys_mb": 159.85379791259766,
       "num_gc": 220,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.00032491131795382315
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.00047471880025935786
     },
     {
-      "elapsed_sec": 865.001852083,
-      "heap_alloc_mb": 218.90286254882812,
-      "sys_mb": 274.6575393676758,
-      "num_gc": 220,
-      "num_goroutine": 200,
-      "gc_cpu_fraction": 0.00032491131795382315
-    },
-    {
-      "elapsed_sec": 870.00126,
-      "heap_alloc_mb": 143.42350006103516,
-      "sys_mb": 278.6575393676758,
+      "elapsed_sec": 325.001384208,
+      "heap_alloc_mb": 105.81990051269531,
+      "sys_mb": 159.85379791259766,
       "num_gc": 221,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0003236701052234717
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.00046735984661100204
     },
     {
-      "elapsed_sec": 875.001600041,
-      "heap_alloc_mb": 183.8926544189453,
-      "sys_mb": 278.6575393676758,
-      "num_gc": 221,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0003236701052234717
-    },
-    {
-      "elapsed_sec": 880.001482041,
-      "heap_alloc_mb": 222.80693817138672,
-      "sys_mb": 278.6575393676758,
-      "num_gc": 221,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0003236701052234717
-    },
-    {
-      "elapsed_sec": 885.001552541,
-      "heap_alloc_mb": 144.66788482666016,
-      "sys_mb": 282.6575393676758,
+      "elapsed_sec": 330.000978,
+      "heap_alloc_mb": 81.16117858886719,
+      "sys_mb": 168.10379791259766,
       "num_gc": 222,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00032157258921938444
+      "num_goroutine": 205,
+      "gc_cpu_fraction": 0.0004613394256807081
     },
     {
-      "elapsed_sec": 890.001559125,
-      "heap_alloc_mb": 187.59618377685547,
-      "sys_mb": 282.6575393676758,
+      "elapsed_sec": 335.001261333,
+      "heap_alloc_mb": 120.82377624511719,
+      "sys_mb": 168.10379791259766,
       "num_gc": 222,
-      "num_goroutine": 189,
-      "gc_cpu_fraction": 0.00032157258921938444
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.0004613394256807081
     },
     {
-      "elapsed_sec": 895.001467083,
-      "heap_alloc_mb": 226.50101470947266,
-      "sys_mb": 282.6575393676758,
-      "num_gc": 222,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.00032157258921938444
-    },
-    {
-      "elapsed_sec": 900.00058175,
-      "heap_alloc_mb": 141.22728729248047,
-      "sys_mb": 290.9700393676758,
+      "elapsed_sec": 340.001475875,
+      "heap_alloc_mb": 93.97845458984375,
+      "sys_mb": 168.10379791259766,
       "num_gc": 223,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.00032200939628509697
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.00045510690365700945
     },
     {
-      "elapsed_sec": 905.001048291,
-      "heap_alloc_mb": 181.16767120361328,
-      "sys_mb": 290.9700393676758,
+      "elapsed_sec": 345.0003245,
+      "heap_alloc_mb": 135.78044891357422,
+      "sys_mb": 168.10379791259766,
       "num_gc": 223,
-      "num_goroutine": 201,
-      "gc_cpu_fraction": 0.00032200939628509697
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.00045510690365700945
     },
     {
-      "elapsed_sec": 910.001520083,
-      "heap_alloc_mb": 220.7269744873047,
-      "sys_mb": 290.9700393676758,
-      "num_gc": 223,
-      "num_goroutine": 201,
-      "gc_cpu_fraction": 0.00032200939628509697
-    },
-    {
-      "elapsed_sec": 915.001363208,
-      "heap_alloc_mb": 139.77861785888672,
-      "sys_mb": 295.0325393676758,
+      "elapsed_sec": 350.00115225,
+      "heap_alloc_mb": 108.93323516845703,
+      "sys_mb": 168.10379791259766,
       "num_gc": 224,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0003208438808377669
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0004499858424983369
     },
     {
-      "elapsed_sec": 920.001625875,
-      "heap_alloc_mb": 179.0625991821289,
-      "sys_mb": 295.0325393676758,
-      "num_gc": 224,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0003208438808377669
-    },
-    {
-      "elapsed_sec": 925.001601541,
-      "heap_alloc_mb": 219.1934585571289,
-      "sys_mb": 295.0325393676758,
-      "num_gc": 224,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0003208438808377669
-    },
-    {
-      "elapsed_sec": 930.001491,
-      "heap_alloc_mb": 258.0293197631836,
-      "sys_mb": 295.0950393676758,
-      "num_gc": 224,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.0003208438808377669
-    },
-    {
-      "elapsed_sec": 935.000728166,
-      "heap_alloc_mb": 174.74678802490234,
-      "sys_mb": 299.0950393676758,
+      "elapsed_sec": 355.001324583,
+      "heap_alloc_mb": 83.98668670654297,
+      "sys_mb": 172.10379791259766,
       "num_gc": 225,
-      "num_goroutine": 188,
-      "gc_cpu_fraction": 0.0003196824711842149
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0004468138410191776
     },
     {
-      "elapsed_sec": 940.001288916,
-      "heap_alloc_mb": 213.86346435546875,
-      "sys_mb": 299.0950393676758,
+      "elapsed_sec": 360.001799958,
+      "heap_alloc_mb": 120.63565063476562,
+      "sys_mb": 172.10379791259766,
       "num_gc": 225,
-      "num_goroutine": 192,
-      "gc_cpu_fraction": 0.0003196824711842149
+      "num_goroutine": 220,
+      "gc_cpu_fraction": 0.0004468138410191776
     },
     {
-      "elapsed_sec": 945.00149725,
-      "heap_alloc_mb": 251.9751968383789,
-      "sys_mb": 299.0950393676758,
-      "num_gc": 225,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0003196824711842149
-    },
-    {
-      "elapsed_sec": 950.001518083,
-      "heap_alloc_mb": 165.2968521118164,
-      "sys_mb": 303.0950393676758,
+      "elapsed_sec": 365.001264041,
+      "heap_alloc_mb": 99.04273986816406,
+      "sys_mb": 172.10379791259766,
       "num_gc": 226,
-      "num_goroutine": 190,
-      "gc_cpu_fraction": 0.0003188984274077509
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.0004405986479536578
     },
     {
-      "elapsed_sec": 955.0014675,
-      "heap_alloc_mb": 205.2173614501953,
-      "sys_mb": 303.0950393676758,
+      "elapsed_sec": 370.000147916,
+      "heap_alloc_mb": 140.0367660522461,
+      "sys_mb": 172.10379791259766,
       "num_gc": 226,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0003188984274077509
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.0004405986479536578
     },
     {
-      "elapsed_sec": 960.001852875,
-      "heap_alloc_mb": 244.8874282836914,
-      "sys_mb": 303.0950393676758,
-      "num_gc": 226,
-      "num_goroutine": 194,
-      "gc_cpu_fraction": 0.0003188984274077509
-    },
-    {
-      "elapsed_sec": 965.000333458,
-      "heap_alloc_mb": 155.85983276367188,
-      "sys_mb": 311.0950393676758,
+      "elapsed_sec": 375.0012535,
+      "heap_alloc_mb": 114.27977752685547,
+      "sys_mb": 172.10379791259766,
       "num_gc": 227,
-      "num_goroutine": 193,
-      "gc_cpu_fraction": 0.00031719554566298424
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.00043459351611628517
     },
     {
-      "elapsed_sec": 970.001647083,
-      "heap_alloc_mb": 197.61998748779297,
-      "sys_mb": 311.0950393676758,
-      "num_gc": 227,
-      "num_goroutine": 187,
-      "gc_cpu_fraction": 0.00031719554566298424
-    },
-    {
-      "elapsed_sec": 975.000607541,
-      "heap_alloc_mb": 236.44025421142578,
-      "sys_mb": 311.0950393676758,
-      "num_gc": 227,
-      "num_goroutine": 191,
-      "gc_cpu_fraction": 0.00031719554566298424
-    },
-    {
-      "elapsed_sec": 980.001271291,
-      "heap_alloc_mb": 275.84458923339844,
-      "sys_mb": 311.0950393676758,
-      "num_gc": 227,
-      "num_goroutine": 196,
-      "gc_cpu_fraction": 0.00031719554566298424
-    },
-    {
-      "elapsed_sec": 985.000684916,
-      "heap_alloc_mb": 186.04286193847656,
-      "sys_mb": 315.0950393676758,
+      "elapsed_sec": 380.000310916,
+      "heap_alloc_mb": 89.87173461914062,
+      "sys_mb": 172.10379791259766,
       "num_gc": 228,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0003173935419567444
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0004284821180285385
     },
     {
-      "elapsed_sec": 990.001722375,
-      "heap_alloc_mb": 224.1685562133789,
-      "sys_mb": 315.0950393676758,
+      "elapsed_sec": 385.001267125,
+      "heap_alloc_mb": 130.4442596435547,
+      "sys_mb": 172.10379791259766,
       "num_gc": 228,
-      "num_goroutine": 200,
-      "gc_cpu_fraction": 0.0003173935419567444
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0004284821180285385
     },
     {
-      "elapsed_sec": 995.001354625,
-      "heap_alloc_mb": 266.6573486328125,
-      "sys_mb": 315.0950393676758,
-      "num_gc": 228,
-      "num_goroutine": 195,
-      "gc_cpu_fraction": 0.0003173935419567444
-    },
-    {
-      "elapsed_sec": 1000.001318458,
-      "heap_alloc_mb": 172.064208984375,
-      "sys_mb": 315.1575393676758,
+      "elapsed_sec": 390.001254958,
+      "heap_alloc_mb": 103.52769470214844,
+      "sys_mb": 172.10379791259766,
       "num_gc": 229,
-      "num_goroutine": 199,
-      "gc_cpu_fraction": 0.0003155671325870182
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0004227581855571466
     },
     {
-      "elapsed_sec": 1005.001413791,
-      "heap_alloc_mb": 193.13619232177734,
-      "sys_mb": 315.1575393676758,
+      "elapsed_sec": 395.001185083,
+      "heap_alloc_mb": 143.72074127197266,
+      "sys_mb": 172.10379791259766,
       "num_gc": 229,
+      "num_goroutine": 218,
+      "gc_cpu_fraction": 0.0004227581855571466
+    },
+    {
+      "elapsed_sec": 400.000538625,
+      "heap_alloc_mb": 119.84719848632812,
+      "sys_mb": 176.42411041259766,
+      "num_gc": 230,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0004171199181892796
+    },
+    {
+      "elapsed_sec": 405.001141083,
+      "heap_alloc_mb": 90.68154907226562,
+      "sys_mb": 176.42411041259766,
+      "num_gc": 231,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.0004115280949499087
+    },
+    {
+      "elapsed_sec": 410.001231833,
+      "heap_alloc_mb": 129.61636352539062,
+      "sys_mb": 176.42411041259766,
+      "num_gc": 231,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0004115280949499087
+    },
+    {
+      "elapsed_sec": 415.001035791,
+      "heap_alloc_mb": 102.28130340576172,
+      "sys_mb": 180.42411041259766,
+      "num_gc": 232,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0004061921450970453
+    },
+    {
+      "elapsed_sec": 420.000374708,
+      "heap_alloc_mb": 142.5893096923828,
+      "sys_mb": 180.42411041259766,
+      "num_gc": 232,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.0004061921450970453
+    },
+    {
+      "elapsed_sec": 425.001205125,
+      "heap_alloc_mb": 112.1500473022461,
+      "sys_mb": 184.48661041259766,
+      "num_gc": 233,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.00040695295694180474
+    },
+    {
+      "elapsed_sec": 430.001299416,
+      "heap_alloc_mb": 151.43788146972656,
+      "sys_mb": 184.54911041259766,
+      "num_gc": 233,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.00040695295694180474
+    },
+    {
+      "elapsed_sec": 435.001286083,
+      "heap_alloc_mb": 122.05944061279297,
+      "sys_mb": 184.54911041259766,
+      "num_gc": 234,
+      "num_goroutine": 203,
+      "gc_cpu_fraction": 0.00040318962634290964
+    },
+    {
+      "elapsed_sec": 440.001442833,
+      "heap_alloc_mb": 87.16704559326172,
+      "sys_mb": 184.61161041259766,
+      "num_gc": 235,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.0004040219935254904
+    },
+    {
+      "elapsed_sec": 445.001438375,
+      "heap_alloc_mb": 126.77921295166016,
+      "sys_mb": 184.61161041259766,
+      "num_gc": 235,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.0004040219935254904
+    },
+    {
+      "elapsed_sec": 450.001490291,
+      "heap_alloc_mb": 91.65167999267578,
+      "sys_mb": 188.61161041259766,
+      "num_gc": 236,
+      "num_goroutine": 218,
+      "gc_cpu_fraction": 0.00040090736641283696
+    },
+    {
+      "elapsed_sec": 455.000769583,
+      "heap_alloc_mb": 133.93050384521484,
+      "sys_mb": 188.61161041259766,
+      "num_gc": 236,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.00040090736641283696
+    },
+    {
+      "elapsed_sec": 460.001579541,
+      "heap_alloc_mb": 100.55996704101562,
+      "sys_mb": 188.86161041259766,
+      "num_gc": 237,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.0003959954187166072
+    },
+    {
+      "elapsed_sec": 465.0013665,
+      "heap_alloc_mb": 141.5445327758789,
+      "sys_mb": 188.86161041259766,
+      "num_gc": 237,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0003959954187166072
+    },
+    {
+      "elapsed_sec": 470.001389791,
+      "heap_alloc_mb": 105.97997283935547,
+      "sys_mb": 192.86161041259766,
+      "num_gc": 238,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.0003956148516991115
+    },
+    {
+      "elapsed_sec": 475.001280833,
+      "heap_alloc_mb": 148.02405548095703,
+      "sys_mb": 192.86161041259766,
+      "num_gc": 238,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.0003956148516991115
+    },
+    {
+      "elapsed_sec": 480.001169375,
+      "heap_alloc_mb": 111.08152770996094,
+      "sys_mb": 192.86161041259766,
+      "num_gc": 239,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.00039359729897078246
+    },
+    {
+      "elapsed_sec": 485.001186083,
+      "heap_alloc_mb": 151.09107208251953,
+      "sys_mb": 192.86161041259766,
+      "num_gc": 239,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.00039359729897078246
+    },
+    {
+      "elapsed_sec": 490.000625375,
+      "heap_alloc_mb": 112.76127624511719,
+      "sys_mb": 192.86161041259766,
+      "num_gc": 240,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.00039068392121320003
+    },
+    {
+      "elapsed_sec": 495.001097916,
+      "heap_alloc_mb": 154.36417388916016,
+      "sys_mb": 192.86161041259766,
+      "num_gc": 240,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.00039068392121320003
+    },
+    {
+      "elapsed_sec": 500.001291833,
+      "heap_alloc_mb": 115.31300354003906,
+      "sys_mb": 196.86161041259766,
+      "num_gc": 241,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.00038771456488865787
+    },
+    {
+      "elapsed_sec": 505.001247541,
+      "heap_alloc_mb": 156.00762176513672,
+      "sys_mb": 196.86161041259766,
+      "num_gc": 241,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.00038771456488865787
+    },
+    {
+      "elapsed_sec": 510.00026975,
+      "heap_alloc_mb": 114.52867889404297,
+      "sys_mb": 200.86161041259766,
+      "num_gc": 242,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.00038515671651608024
+    },
+    {
+      "elapsed_sec": 515.00126975,
+      "heap_alloc_mb": 155.18789672851562,
+      "sys_mb": 200.86161041259766,
+      "num_gc": 242,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.00038515671651608024
+    },
+    {
+      "elapsed_sec": 520.000316875,
+      "heap_alloc_mb": 113.59490966796875,
+      "sys_mb": 200.86161041259766,
+      "num_gc": 243,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.00038255324575448994
+    },
+    {
+      "elapsed_sec": 525.001225583,
+      "heap_alloc_mb": 154.09007263183594,
+      "sys_mb": 200.86161041259766,
+      "num_gc": 243,
+      "num_goroutine": 202,
+      "gc_cpu_fraction": 0.00038255324575448994
+    },
+    {
+      "elapsed_sec": 530.000848833,
+      "heap_alloc_mb": 107.75479888916016,
+      "sys_mb": 204.86161041259766,
+      "num_gc": 244,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.00037825486728388063
+    },
+    {
+      "elapsed_sec": 535.001170833,
+      "heap_alloc_mb": 147.1913604736328,
+      "sys_mb": 204.86161041259766,
+      "num_gc": 244,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.00037825486728388063
+    },
+    {
+      "elapsed_sec": 540.001384,
+      "heap_alloc_mb": 100.78678894042969,
+      "sys_mb": 208.92803192138672,
+      "num_gc": 245,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.00037462176959524273
+    },
+    {
+      "elapsed_sec": 545.001111916,
+      "heap_alloc_mb": 141.62838745117188,
+      "sys_mb": 208.92803192138672,
+      "num_gc": 245,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.00037462176959524273
+    },
+    {
+      "elapsed_sec": 550.001270666,
+      "heap_alloc_mb": 95.04185485839844,
+      "sys_mb": 208.92803192138672,
+      "num_gc": 246,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.00037124205538490704
+    },
+    {
+      "elapsed_sec": 555.000698041,
+      "heap_alloc_mb": 134.22354888916016,
+      "sys_mb": 208.92803192138672,
+      "num_gc": 246,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.00037124205538490704
+    },
+    {
+      "elapsed_sec": 560.002475083,
+      "heap_alloc_mb": 173.24073791503906,
+      "sys_mb": 208.92803192138672,
+      "num_gc": 246,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.00037124205538490704
+    },
+    {
+      "elapsed_sec": 565.000886458,
+      "heap_alloc_mb": 126.59033203125,
+      "sys_mb": 213.24053192138672,
+      "num_gc": 247,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.0003731814190127073
+    },
+    {
+      "elapsed_sec": 570.00038525,
+      "heap_alloc_mb": 163.36234283447266,
+      "sys_mb": 213.24053192138672,
+      "num_gc": 247,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0003731814190127073
+    },
+    {
+      "elapsed_sec": 575.00119025,
+      "heap_alloc_mb": 117.81304931640625,
+      "sys_mb": 213.30303192138672,
+      "num_gc": 248,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0003697027722248054
+    },
+    {
+      "elapsed_sec": 580.001228208,
+      "heap_alloc_mb": 156.3003158569336,
+      "sys_mb": 213.30303192138672,
+      "num_gc": 248,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0003697027722248054
+    },
+    {
+      "elapsed_sec": 585.001201,
+      "heap_alloc_mb": 107.09275817871094,
+      "sys_mb": 213.36553192138672,
+      "num_gc": 249,
+      "num_goroutine": 217,
+      "gc_cpu_fraction": 0.000366582584877254
+    },
+    {
+      "elapsed_sec": 590.000577791,
+      "heap_alloc_mb": 146.7290267944336,
+      "sys_mb": 213.36553192138672,
+      "num_gc": 249,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.000366582584877254
+    },
+    {
+      "elapsed_sec": 595.001154041,
+      "heap_alloc_mb": 185.49982452392578,
+      "sys_mb": 213.36553192138672,
+      "num_gc": 249,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.000366582584877254
+    },
+    {
+      "elapsed_sec": 600.001167458,
+      "heap_alloc_mb": 136.78504180908203,
+      "sys_mb": 217.36553192138672,
+      "num_gc": 250,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.00036227964580833033
+    },
+    {
+      "elapsed_sec": 605.001209208,
+      "heap_alloc_mb": 174.57223510742188,
+      "sys_mb": 217.36553192138672,
+      "num_gc": 250,
+      "num_goroutine": 220,
+      "gc_cpu_fraction": 0.00036227964580833033
+    },
+    {
+      "elapsed_sec": 610.001100541,
+      "heap_alloc_mb": 125.81307220458984,
+      "sys_mb": 217.36553192138672,
+      "num_gc": 251,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.00035796302688390123
+    },
+    {
+      "elapsed_sec": 615.000162958,
+      "heap_alloc_mb": 165.85393524169922,
+      "sys_mb": 217.36553192138672,
+      "num_gc": 251,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.00035796302688390123
+    },
+    {
+      "elapsed_sec": 620.001401166,
+      "heap_alloc_mb": 112.77536010742188,
+      "sys_mb": 221.36553192138672,
+      "num_gc": 252,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.0003537182504969757
+    },
+    {
+      "elapsed_sec": 625.00088575,
+      "heap_alloc_mb": 153.2544403076172,
+      "sys_mb": 221.36553192138672,
+      "num_gc": 252,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0003537182504969757
+    },
+    {
+      "elapsed_sec": 630.001179416,
+      "heap_alloc_mb": 189.92081451416016,
+      "sys_mb": 221.36553192138672,
+      "num_gc": 252,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.0003537182504969757
+    },
+    {
+      "elapsed_sec": 635.001200458,
+      "heap_alloc_mb": 138.59332275390625,
+      "sys_mb": 225.36553192138672,
+      "num_gc": 253,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.00034968159489061194
+    },
+    {
+      "elapsed_sec": 640.001289125,
+      "heap_alloc_mb": 177.76290130615234,
+      "sys_mb": 225.36553192138672,
+      "num_gc": 253,
+      "num_goroutine": 205,
+      "gc_cpu_fraction": 0.00034968159489061194
+    },
+    {
+      "elapsed_sec": 645.0014345,
+      "heap_alloc_mb": 123.62594604492188,
+      "sys_mb": 225.36553192138672,
+      "num_gc": 254,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.00034600375383207304
+    },
+    {
+      "elapsed_sec": 650.00105175,
+      "heap_alloc_mb": 161.28833770751953,
+      "sys_mb": 225.36553192138672,
+      "num_gc": 254,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.00034600375383207304
+    },
+    {
+      "elapsed_sec": 655.000957416,
+      "heap_alloc_mb": 105.95637512207031,
+      "sys_mb": 229.36553192138672,
+      "num_gc": 255,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.00034220746642012846
+    },
+    {
+      "elapsed_sec": 660.000479708,
+      "heap_alloc_mb": 144.1455841064453,
+      "sys_mb": 229.36553192138672,
+      "num_gc": 255,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.00034220746642012846
+    },
+    {
+      "elapsed_sec": 665.001018583,
+      "heap_alloc_mb": 185.47161102294922,
+      "sys_mb": 229.36553192138672,
+      "num_gc": 255,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.00034220746642012846
+    },
+    {
+      "elapsed_sec": 670.001459625,
+      "heap_alloc_mb": 128.38103485107422,
+      "sys_mb": 229.36553192138672,
+      "num_gc": 256,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.00034201976934982635
+    },
+    {
+      "elapsed_sec": 675.000980541,
+      "heap_alloc_mb": 166.59861755371094,
+      "sys_mb": 229.36553192138672,
+      "num_gc": 256,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.00034201976934982635
+    },
+    {
+      "elapsed_sec": 680.001956458,
+      "heap_alloc_mb": 111.35802459716797,
+      "sys_mb": 233.36553192138672,
+      "num_gc": 257,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.00033874325167705357
+    },
+    {
+      "elapsed_sec": 685.001288416,
+      "heap_alloc_mb": 151.83739471435547,
+      "sys_mb": 233.36553192138672,
+      "num_gc": 257,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.00033874325167705357
+    },
+    {
+      "elapsed_sec": 690.000342916,
+      "heap_alloc_mb": 190.16886138916016,
+      "sys_mb": 233.36553192138672,
+      "num_gc": 257,
+      "num_goroutine": 205,
+      "gc_cpu_fraction": 0.00033874325167705357
+    },
+    {
+      "elapsed_sec": 695.00076,
+      "heap_alloc_mb": 135.35520935058594,
+      "sys_mb": 233.36553192138672,
+      "num_gc": 258,
+      "num_goroutine": 197,
+      "gc_cpu_fraction": 0.0003361310469265014
+    },
+    {
+      "elapsed_sec": 700.001285125,
+      "heap_alloc_mb": 169.8760757446289,
+      "sys_mb": 233.36553192138672,
+      "num_gc": 258,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.0003361310469265014
+    },
+    {
+      "elapsed_sec": 705.000493833,
+      "heap_alloc_mb": 111.77075958251953,
+      "sys_mb": 237.36553192138672,
+      "num_gc": 259,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.0003333867394948569
+    },
+    {
+      "elapsed_sec": 710.001251375,
+      "heap_alloc_mb": 150.4662322998047,
+      "sys_mb": 237.36553192138672,
+      "num_gc": 259,
+      "num_goroutine": 205,
+      "gc_cpu_fraction": 0.0003333867394948569
+    },
+    {
+      "elapsed_sec": 715.00137575,
+      "heap_alloc_mb": 188.50751495361328,
+      "sys_mb": 237.36553192138672,
+      "num_gc": 259,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0003333867394948569
+    },
+    {
+      "elapsed_sec": 720.001460125,
+      "heap_alloc_mb": 129.43253326416016,
+      "sys_mb": 241.61553192138672,
+      "num_gc": 260,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.00033064760351032363
+    },
+    {
+      "elapsed_sec": 725.001240541,
+      "heap_alloc_mb": 170.0357208251953,
+      "sys_mb": 241.61553192138672,
+      "num_gc": 260,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.00033064760351032363
+    },
+    {
+      "elapsed_sec": 730.001254166,
+      "heap_alloc_mb": 206.9274139404297,
+      "sys_mb": 241.61553192138672,
+      "num_gc": 260,
+      "num_goroutine": 219,
+      "gc_cpu_fraction": 0.00033064760351032363
+    },
+    {
+      "elapsed_sec": 735.001324875,
+      "heap_alloc_mb": 142.89020538330078,
+      "sys_mb": 245.67803192138672,
+      "num_gc": 261,
+      "num_goroutine": 220,
+      "gc_cpu_fraction": 0.0003281023109538501
+    },
+    {
+      "elapsed_sec": 740.00119475,
+      "heap_alloc_mb": 183.40621185302734,
+      "sys_mb": 245.67803192138672,
+      "num_gc": 261,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0003281023109538501
+    },
+    {
+      "elapsed_sec": 745.000334791,
+      "heap_alloc_mb": 125.1654052734375,
+      "sys_mb": 245.74053192138672,
+      "num_gc": 262,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.00032546249190244016
+    },
+    {
+      "elapsed_sec": 750.001308541,
+      "heap_alloc_mb": 163.41077423095703,
+      "sys_mb": 245.74053192138672,
+      "num_gc": 262,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.00032546249190244016
+    },
+    {
+      "elapsed_sec": 755.001140458,
+      "heap_alloc_mb": 201.50830841064453,
+      "sys_mb": 245.74053192138672,
+      "num_gc": 262,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.00032546249190244016
+    },
+    {
+      "elapsed_sec": 760.001497916,
+      "heap_alloc_mb": 141.19110107421875,
+      "sys_mb": 245.80303192138672,
+      "num_gc": 263,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.0003224622618498991
+    },
+    {
+      "elapsed_sec": 765.000876041,
+      "heap_alloc_mb": 180.51806640625,
+      "sys_mb": 245.80303192138672,
+      "num_gc": 263,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.0003224622618498991
+    },
+    {
+      "elapsed_sec": 770.001200833,
+      "heap_alloc_mb": 118.39553833007812,
+      "sys_mb": 245.80303192138672,
+      "num_gc": 264,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.00031974495044761954
+    },
+    {
+      "elapsed_sec": 775.0012095,
+      "heap_alloc_mb": 158.35987854003906,
+      "sys_mb": 245.80303192138672,
+      "num_gc": 264,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.00031974495044761954
+    },
+    {
+      "elapsed_sec": 780.000928041,
+      "heap_alloc_mb": 193.41313934326172,
+      "sys_mb": 245.80303192138672,
+      "num_gc": 264,
+      "num_goroutine": 223,
+      "gc_cpu_fraction": 0.00031974495044761954
+    },
+    {
+      "elapsed_sec": 785.001171833,
+      "heap_alloc_mb": 132.0133056640625,
+      "sys_mb": 249.80303192138672,
+      "num_gc": 265,
+      "num_goroutine": 217,
+      "gc_cpu_fraction": 0.0003165969782305016
+    },
+    {
+      "elapsed_sec": 790.001244958,
+      "heap_alloc_mb": 172.0785903930664,
+      "sys_mb": 249.80303192138672,
+      "num_gc": 265,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.0003165969782305016
+    },
+    {
+      "elapsed_sec": 795.001225083,
+      "heap_alloc_mb": 212.94133758544922,
+      "sys_mb": 249.80303192138672,
+      "num_gc": 265,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0003165969782305016
+    },
+    {
+      "elapsed_sec": 800.000239958,
+      "heap_alloc_mb": 147.5741195678711,
+      "sys_mb": 249.80303192138672,
+      "num_gc": 266,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.0003143202360786313
+    },
+    {
+      "elapsed_sec": 805.0002835,
+      "heap_alloc_mb": 187.68528747558594,
+      "sys_mb": 249.80303192138672,
+      "num_gc": 266,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.0003143202360786313
+    },
+    {
+      "elapsed_sec": 810.001270375,
+      "heap_alloc_mb": 121.44123077392578,
+      "sys_mb": 249.90850067138672,
+      "num_gc": 267,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.00031183695303070184
+    },
+    {
+      "elapsed_sec": 815.001235,
+      "heap_alloc_mb": 161.50230407714844,
+      "sys_mb": 249.90850067138672,
+      "num_gc": 267,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.00031183695303070184
+    },
+    {
+      "elapsed_sec": 820.001152875,
+      "heap_alloc_mb": 200.36582946777344,
+      "sys_mb": 249.90850067138672,
+      "num_gc": 267,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.00031183695303070184
+    },
+    {
+      "elapsed_sec": 825.001158458,
+      "heap_alloc_mb": 133.30844116210938,
+      "sys_mb": 254.15850067138672,
+      "num_gc": 268,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.000308942693998733
+    },
+    {
+      "elapsed_sec": 830.001254,
+      "heap_alloc_mb": 170.3848876953125,
+      "sys_mb": 254.15850067138672,
+      "num_gc": 268,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.000308942693998733
+    },
+    {
+      "elapsed_sec": 835.001146625,
+      "heap_alloc_mb": 209.3974609375,
+      "sys_mb": 254.15850067138672,
+      "num_gc": 268,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.000308942693998733
+    },
+    {
+      "elapsed_sec": 840.001231125,
+      "heap_alloc_mb": 141.9068145751953,
+      "sys_mb": 254.15850067138672,
+      "num_gc": 269,
+      "num_goroutine": 213,
+      "gc_cpu_fraction": 0.0003058504780772419
+    },
+    {
+      "elapsed_sec": 845.001174916,
+      "heap_alloc_mb": 182.2043228149414,
+      "sys_mb": 254.15850067138672,
+      "num_gc": 269,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0003058504780772419
+    },
+    {
+      "elapsed_sec": 850.001178,
+      "heap_alloc_mb": 220.1862335205078,
+      "sys_mb": 254.15850067138672,
+      "num_gc": 269,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.0003058504780772419
+    },
+    {
+      "elapsed_sec": 855.000379708,
+      "heap_alloc_mb": 151.44921875,
+      "sys_mb": 262.1585006713867,
+      "num_gc": 270,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0003030129112183006
+    },
+    {
+      "elapsed_sec": 860.00135675,
+      "heap_alloc_mb": 190.9588165283203,
+      "sys_mb": 262.1585006713867,
+      "num_gc": 270,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.0003030129112183006
+    },
+    {
+      "elapsed_sec": 865.001235833,
+      "heap_alloc_mb": 120.44037628173828,
+      "sys_mb": 262.1585006713867,
+      "num_gc": 271,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.00030084322299159217
+    },
+    {
+      "elapsed_sec": 870.000779791,
+      "heap_alloc_mb": 158.70893096923828,
+      "sys_mb": 262.1585006713867,
+      "num_gc": 271,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.00030084322299159217
+    },
+    {
+      "elapsed_sec": 875.001208833,
+      "heap_alloc_mb": 198.60167694091797,
+      "sys_mb": 262.1585006713867,
+      "num_gc": 271,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.00030084322299159217
+    },
+    {
+      "elapsed_sec": 880.000459791,
+      "heap_alloc_mb": 127.84339904785156,
+      "sys_mb": 266.1585006713867,
+      "num_gc": 272,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.00029958039288863637
+    },
+    {
+      "elapsed_sec": 885.001573541,
+      "heap_alloc_mb": 164.92868041992188,
+      "sys_mb": 266.1585006713867,
+      "num_gc": 272,
+      "num_goroutine": 217,
+      "gc_cpu_fraction": 0.00029958039288863637
+    },
+    {
+      "elapsed_sec": 890.001259333,
+      "heap_alloc_mb": 206.63428497314453,
+      "sys_mb": 266.1585006713867,
+      "num_gc": 272,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.00029958039288863637
+    },
+    {
+      "elapsed_sec": 895.001216166,
+      "heap_alloc_mb": 135.3675537109375,
+      "sys_mb": 266.4085006713867,
+      "num_gc": 273,
+      "num_goroutine": 204,
+      "gc_cpu_fraction": 0.0002984033025454923
+    },
+    {
+      "elapsed_sec": 900.001349875,
+      "heap_alloc_mb": 171.62338256835938,
+      "sys_mb": 266.4085006713867,
+      "num_gc": 273,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0002984033025454923
+    },
+    {
+      "elapsed_sec": 905.001394041,
+      "heap_alloc_mb": 210.77367401123047,
+      "sys_mb": 266.4085006713867,
+      "num_gc": 273,
+      "num_goroutine": 209,
+      "gc_cpu_fraction": 0.0002984033025454923
+    },
+    {
+      "elapsed_sec": 910.001400916,
+      "heap_alloc_mb": 137.68167114257812,
+      "sys_mb": 270.4085006713867,
+      "num_gc": 274,
+      "num_goroutine": 208,
+      "gc_cpu_fraction": 0.0002961038095341447
+    },
+    {
+      "elapsed_sec": 915.00116775,
+      "heap_alloc_mb": 179.42449951171875,
+      "sys_mb": 270.4085006713867,
+      "num_gc": 274,
+      "num_goroutine": 201,
+      "gc_cpu_fraction": 0.0002961038095341447
+    },
+    {
+      "elapsed_sec": 920.001044875,
+      "heap_alloc_mb": 217.2367706298828,
+      "sys_mb": 270.4085006713867,
+      "num_gc": 274,
+      "num_goroutine": 200,
+      "gc_cpu_fraction": 0.0002961038095341447
+    },
+    {
+      "elapsed_sec": 925.001236833,
+      "heap_alloc_mb": 141.79402923583984,
+      "sys_mb": 274.5374221801758,
+      "num_gc": 275,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.00029452308827932584
+    },
+    {
+      "elapsed_sec": 930.001402666,
+      "heap_alloc_mb": 179.30215454101562,
+      "sys_mb": 274.5374221801758,
+      "num_gc": 275,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.00029452308827932584
+    },
+    {
+      "elapsed_sec": 935.001218041,
+      "heap_alloc_mb": 219.63803100585938,
+      "sys_mb": 274.5374221801758,
+      "num_gc": 275,
+      "num_goroutine": 206,
+      "gc_cpu_fraction": 0.00029452308827932584
+    },
+    {
+      "elapsed_sec": 940.000600916,
+      "heap_alloc_mb": 143.54620361328125,
+      "sys_mb": 274.5999221801758,
+      "num_gc": 276,
+      "num_goroutine": 207,
+      "gc_cpu_fraction": 0.000291783538576924
+    },
+    {
+      "elapsed_sec": 945.001188125,
+      "heap_alloc_mb": 181.80917358398438,
+      "sys_mb": 274.5999221801758,
+      "num_gc": 276,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.000291783538576924
+    },
+    {
+      "elapsed_sec": 950.000502291,
+      "heap_alloc_mb": 220.9023208618164,
+      "sys_mb": 274.5999221801758,
+      "num_gc": 276,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.000291783538576924
+    },
+    {
+      "elapsed_sec": 955.001194291,
+      "heap_alloc_mb": 145.1314697265625,
+      "sys_mb": 274.6624221801758,
+      "num_gc": 277,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.0002894854443537664
+    },
+    {
+      "elapsed_sec": 960.000573833,
+      "heap_alloc_mb": 183.86031341552734,
+      "sys_mb": 274.6624221801758,
+      "num_gc": 277,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.0002894854443537664
+    },
+    {
+      "elapsed_sec": 965.001441041,
+      "heap_alloc_mb": 222.72119903564453,
+      "sys_mb": 274.6624221801758,
+      "num_gc": 277,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.0002894854443537664
+    },
+    {
+      "elapsed_sec": 970.001331625,
+      "heap_alloc_mb": 145.5127716064453,
+      "sys_mb": 278.6624221801758,
+      "num_gc": 278,
+      "num_goroutine": 211,
+      "gc_cpu_fraction": 0.0002875476896162499
+    },
+    {
+      "elapsed_sec": 975.001224,
+      "heap_alloc_mb": 184.15587615966797,
+      "sys_mb": 278.6624221801758,
+      "num_gc": 278,
+      "num_goroutine": 212,
+      "gc_cpu_fraction": 0.0002875476896162499
+    },
+    {
+      "elapsed_sec": 980.000689041,
+      "heap_alloc_mb": 222.1305160522461,
+      "sys_mb": 278.6624221801758,
+      "num_gc": 278,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.0002875476896162499
+    },
+    {
+      "elapsed_sec": 985.000373333,
+      "heap_alloc_mb": 145.93795776367188,
+      "sys_mb": 282.9124221801758,
+      "num_gc": 279,
+      "num_goroutine": 210,
+      "gc_cpu_fraction": 0.0002855066675967001
+    },
+    {
+      "elapsed_sec": 990.000334125,
+      "heap_alloc_mb": 182.32772064208984,
+      "sys_mb": 282.9124221801758,
+      "num_gc": 279,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.0002855066675967001
+    },
+    {
+      "elapsed_sec": 995.001216625,
+      "heap_alloc_mb": 221.50579071044922,
+      "sys_mb": 282.9124221801758,
+      "num_gc": 279,
+      "num_goroutine": 215,
+      "gc_cpu_fraction": 0.0002855066675967001
+    },
+    {
+      "elapsed_sec": 1000.001285,
+      "heap_alloc_mb": 142.24636840820312,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
+      "num_goroutine": 214,
+      "gc_cpu_fraction": 0.0002842996654169435
+    },
+    {
+      "elapsed_sec": 1005.001227416,
+      "heap_alloc_mb": 161.21543884277344,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
+      "num_goroutine": 181,
+      "gc_cpu_fraction": 0.0002842996654169435
+    },
+    {
+      "elapsed_sec": 1010.000171916,
+      "heap_alloc_mb": 171.52445220947266,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
       "num_goroutine": 164,
-      "gc_cpu_fraction": 0.0003155671325870182
+      "gc_cpu_fraction": 0.0002842996654169435
     },
     {
-      "elapsed_sec": 1010.001442375,
-      "heap_alloc_mb": 201.6921615600586,
-      "sys_mb": 315.1575393676758,
-      "num_gc": 229,
-      "num_goroutine": 153,
-      "gc_cpu_fraction": 0.0003155671325870182
+      "elapsed_sec": 1015.000778,
+      "heap_alloc_mb": 179.49244689941406,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
+      "num_goroutine": 150,
+      "gc_cpu_fraction": 0.0002842996654169435
     },
     {
-      "elapsed_sec": 1015.000713416,
-      "heap_alloc_mb": 208.42589569091797,
-      "sys_mb": 315.1575393676758,
-      "num_gc": 229,
-      "num_goroutine": 146,
-      "gc_cpu_fraction": 0.0003155671325870182
+      "elapsed_sec": 1020.000278083,
+      "heap_alloc_mb": 183.75196075439453,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
+      "num_goroutine": 144,
+      "gc_cpu_fraction": 0.0002842996654169435
     },
     {
-      "elapsed_sec": 1020.001586958,
-      "heap_alloc_mb": 214.38919830322266,
-      "sys_mb": 315.1575393676758,
-      "num_gc": 229,
-      "num_goroutine": 133,
-      "gc_cpu_fraction": 0.0003155671325870182
+      "elapsed_sec": 1025.001152541,
+      "heap_alloc_mb": 187.0914764404297,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
+      "num_goroutine": 139,
+      "gc_cpu_fraction": 0.0002842996654169435
     },
     {
-      "elapsed_sec": 1025.000861708,
-      "heap_alloc_mb": 217.9980926513672,
-      "sys_mb": 315.1575393676758,
-      "num_gc": 229,
-      "num_goroutine": 128,
-      "gc_cpu_fraction": 0.0003155671325870182
+      "elapsed_sec": 1030.000326583,
+      "heap_alloc_mb": 189.31270599365234,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
+      "num_goroutine": 136,
+      "gc_cpu_fraction": 0.0002842996654169435
     },
     {
-      "elapsed_sec": 1030.000701,
-      "heap_alloc_mb": 220.32897186279297,
-      "sys_mb": 315.1575393676758,
-      "num_gc": 229,
+      "elapsed_sec": 1035.001224583,
+      "heap_alloc_mb": 190.80604553222656,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
+      "num_goroutine": 131,
+      "gc_cpu_fraction": 0.0002842996654169435
+    },
+    {
+      "elapsed_sec": 1040.001225458,
+      "heap_alloc_mb": 191.3544464111328,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
+      "num_goroutine": 127,
+      "gc_cpu_fraction": 0.0002842996654169435
+    },
+    {
+      "elapsed_sec": 1045.001171625,
+      "heap_alloc_mb": 191.6314926147461,
+      "sys_mb": 290.9124221801758,
+      "num_gc": 280,
       "num_goroutine": 125,
-      "gc_cpu_fraction": 0.0003155671325870182
-    },
-    {
-      "elapsed_sec": 1035.00087,
-      "heap_alloc_mb": 221.386962890625,
-      "sys_mb": 315.1575393676758,
-      "num_gc": 229,
-      "num_goroutine": 119,
-      "gc_cpu_fraction": 0.0003155671325870182
-    },
-    {
-      "elapsed_sec": 1040.000589125,
-      "heap_alloc_mb": 222.09326171875,
-      "sys_mb": 315.1575393676758,
-      "num_gc": 229,
-      "num_goroutine": 114,
-      "gc_cpu_fraction": 0.0003155671325870182
-    },
-    {
-      "elapsed_sec": 1045.000818208,
-      "heap_alloc_mb": 222.65961456298828,
-      "sys_mb": 315.1575393676758,
-      "num_gc": 229,
-      "num_goroutine": 110,
-      "gc_cpu_fraction": 0.0003155671325870182
-    },
-    {
-      "elapsed_sec": 1050.000853958,
-      "heap_alloc_mb": 222.6611328125,
-      "sys_mb": 315.1575393676758,
-      "num_gc": 229,
-      "num_goroutine": 110,
-      "gc_cpu_fraction": 0.0003155671325870182
+      "gc_cpu_fraction": 0.0002842996654169435
     }
   ],
   "duration": {
-    "creation_sec": 1000.002929042,
-    "total_sec": 1051.471266167
+    "creation_sec": 1000.002345958,
+    "total_sec": 1049.70725175
   }
 }

--- a/test/stress/results.go
+++ b/test/stress/results.go
@@ -43,13 +43,16 @@ type StressTestResults struct {
 
 // TestConfig captures the parameters used for a stress test run.
 type TestConfig struct {
-	NodeCount         int `json:"node_count"`
-	NodeRate          int `json:"node_rate"`
-	TimeoutMinutes    int `json:"timeout_minutes"`
-	ControllerTimeout int `json:"controller_timeout_sec"`
-	MaxConcReconciles int `json:"max_concurrent_reconciles"`
-	APIConcurrency    int `json:"api_concurrency"`
-	DaemonSetCount    int `json:"daemonset_count"`
+	NodeCount             int `json:"node_count"`
+	NodeRate              int `json:"node_rate"`
+	TimeoutMinutes        int `json:"timeout_minutes"`
+	ControllerTimeout     int `json:"controller_timeout_sec"`
+	MaxConcReconciles     int `json:"max_concurrent_reconciles"`
+	APIConcurrency        int `json:"api_concurrency"`
+	DaemonSetCount        int `json:"daemonset_count"`
+	BackgroundPods        int `json:"background_pods"`
+	BackgroundPodMinBytes int `json:"background_pod_min_bytes"`
+	BackgroundPodMaxBytes int `json:"background_pod_max_bytes"`
 }
 
 // LatencyBreakdown captures latency percentiles broken into three phases.

--- a/test/stress/stress_test.go
+++ b/test/stress/stress_test.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/nextdoor/vigil/internal/cacheopts"
 	"github.com/nextdoor/vigil/internal/controller"
 	"github.com/nextdoor/vigil/internal/discovery"
 	"github.com/nextdoor/vigil/internal/inventory"
@@ -68,9 +69,13 @@ func TestStress(t *testing.T) {
 	maxReconciles := envInt("STRESS_MAX_CONCURRENT_RECONCILES", 50)
 	logLevel := envInt("STRESS_LOG_LEVEL", 0)
 	apiConcurrency := envInt("STRESS_API_CONCURRENCY", 150)
+	backgroundPods := envInt("STRESS_BACKGROUND_PODS", 15000)
+	backgroundPodMinBytes := envInt("STRESS_BACKGROUND_POD_MIN_BYTES", 5*1024)
+	backgroundPodMaxBytes := envInt("STRESS_BACKGROUND_POD_MAX_BYTES", 15*1024)
 
-	t.Logf("Stress test config: nodes=%d rate=%d/s timeout=%dm controller-timeout=%ds workers=%d",
-		nodeCount, nodeRate, timeoutMin, controllerTimeout, maxReconciles)
+	t.Logf("Stress test config: nodes=%d rate=%d/s timeout=%dm controller-timeout=%ds workers=%d bg-pods=%d (%d-%dB)",
+		nodeCount, nodeRate, timeoutMin, controllerTimeout, maxReconciles,
+		backgroundPods, backgroundPodMinBytes, backgroundPodMaxBytes)
 
 	deadline := time.Duration(timeoutMin) * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), deadline)
@@ -110,6 +115,7 @@ func TestStress(t *testing.T) {
 		Metrics: metricsserver.Options{
 			BindAddress: "0", // disable HTTP metrics server
 		},
+		Cache:                  cacheopts.New(),
 		HealthProbeBindAddress: "0", // disable health probes
 	})
 	require.NoError(t, err)
@@ -191,6 +197,20 @@ func TestStress(t *testing.T) {
 	t.Logf("Created %d DaemonSets, cached client sees %d", len(daemonSets), len(dsCheck.Items))
 	require.Equal(t, len(daemonSets), len(dsCheck.Items),
 		"cached client should see all DaemonSets")
+
+	// Seed the cluster with non-DS "application" pods so the Pod informer cache
+	// reflects real cluster footprint, not just the tiny pool of DS pods the
+	// controller actually reconciles against.
+	if backgroundPods > 0 {
+		t.Logf("Creating %d background pods (%d-%d bytes each)...",
+			backgroundPods, backgroundPodMinBytes, backgroundPodMaxBytes)
+		bgStart := time.Now()
+		require.NoError(t, createBackgroundPods(ctx, cl, backgroundPods, nodeCount,
+			backgroundPodMinBytes, backgroundPodMaxBytes, apiConcurrency))
+		t.Logf("Created %d background pods in %v", backgroundPods, time.Since(bgStart).Round(time.Second))
+		// Let the informer catch up before we start churn.
+		time.Sleep(5 * time.Second)
+	}
 
 	// ---------- Start resource sampling ----------
 	sampler := NewResourceSampler()
@@ -298,13 +318,16 @@ func TestStress(t *testing.T) {
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		GitSHA:    gitSHA(),
 		TestConfig: TestConfig{
-			NodeCount:         nodeCount,
-			NodeRate:          nodeRate,
-			TimeoutMinutes:    timeoutMin,
-			ControllerTimeout: controllerTimeout,
-			MaxConcReconciles: maxReconciles,
-			APIConcurrency:    apiConcurrency,
-			DaemonSetCount:    len(daemonSets),
+			NodeCount:             nodeCount,
+			NodeRate:              nodeRate,
+			TimeoutMinutes:        timeoutMin,
+			ControllerTimeout:     controllerTimeout,
+			MaxConcReconciles:     maxReconciles,
+			APIConcurrency:        apiConcurrency,
+			DaemonSetCount:        len(daemonSets),
+			BackgroundPods:        backgroundPods,
+			BackgroundPodMinBytes: backgroundPodMinBytes,
+			BackgroundPodMaxBytes: backgroundPodMaxBytes,
 		},
 		Latency: LatencyBreakdown{
 			EndToEnd: LatencyPercentiles{


### PR DESCRIPTION
## Summary

- Shrinks the controller's Pod informer cache from **686 MB → 223 MB peak heap** (−67.5%) at 10k nodes + 15k realistic background pods, by stripping every pod field vigil doesn't read before objects enter the cache.
- Upgrades the stress harness to seed 15,000 non-DS, ~5–15 KB pods so benchmark numbers actually match production behavior (us-west-2 pods were burning 590–705 MB; the old harness under-reported at 276 MB).

Context: k9s in `us1` showed the controller-manager pods sitting at 591–705 MB. Root cause was the Pod informer caching every pod in the cluster with full `ManagedFields`, `ContainerStatuses`, env vars, volumes, and annotations — none of which the reconciler reads. The readiness check only needs `Spec.NodeName`, `OwnerReferences`, `Status.Phase`, and the `PodReady` condition.

## Commits

1. `test(stress): simulate 15k fat background pods in baseline` — adds `STRESS_BACKGROUND_PODS`, `STRESS_BACKGROUND_POD_{MIN,MAX}_BYTES`. These sit in the informer cache but aren't DS-owned, so they never trigger reconciles — same shape as real workload pods.
2. `perf(cache): strip unused pod fields before informer cache` — new `internal/cacheopts` package registering a `cache.TransformFunc` on `*corev1.Pod` plus `TransformStripManagedFields` as `DefaultTransform`. Used by both `cmd/main.go` and the stress harness so the benchmark reflects the shipping cache shape.

## Stress comparison (same seed, 10k nodes, 15k bg pods)

| Metric | Pre | Post | Δ |
|--------|----:|-----:|---|
| Peak heap | 686 MB | 223 MB | **−67.5%** |
| Final heap | 444 MB | 193 MB | −56.5% |
| System mem | 822 MB | 291 MB | −64.6% |
| E2E p50 | 5,011ms | 5,020ms | +0.2% |
| E2E p99 | 34,231ms | 34,222ms | ≈0 |
| Vigil reaction p99 | 1,986ms | 1,979ms | ≈0 |
| Success | 9500/10000 | 9500/10000 | — |

Baseline.json updated to the post-transform numbers.

## Test plan

- [x] `go test -race ./internal/...` (unit + integration — all pass)
- [x] `go build ./...` and `go build -tags=stress ./test/stress/...`
- [x] `make test-stress` on the pre-transform binary (produced the 686 MB baseline)
- [x] `make test-stress` on the post-transform binary (produced the 223 MB baseline now in `baseline.json`)
- [ ] Deploy to `us1` canary and verify pod memory drops in line with the benchmark (≈65% reduction expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)