### PR TITLE
fix(helm): tune RBAC to allow events.k8s.io for the ClusterRole

### DIFF
--- a/charts/vigil-controller/templates/clusterrole.yaml
+++ b/charts/vigil-controller/templates/clusterrole.yaml
@@ -43,4 +43,11 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 {{- end }}


### PR DESCRIPTION
We've faced with https://github.com/Nextdoor/vigil/issues/56 too.
As the chart already has a `ClusterRole` bound with a `ClusterRoleBinding` the minimal fix is to just add needed permissions into it.