### PR TITLE
fix(leader-election): suppress standby lease false positive

### DIFF
--- a/charts/vigil-controller/templates/deployment.yaml
+++ b/charts/vigil-controller/templates/deployment.yaml
@@ -68,6 +68,14 @@ spec:
         {{- range .Values.controllerManager.extraArgs }}
         - {{ . }}
         {{- end }}
+        {{- if .Values.controllerManager.leaderElection.enabled }}
+        env:
+        # Lets the controller read its own lease namespace (issue #70).
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- end }}
         ports:
         - name: metrics
           containerPort: {{ .Values.metricsService.port }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"time"
@@ -22,10 +23,14 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"github.com/go-logr/logr"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -38,6 +43,9 @@ import (
 	"github.com/nextdoor/vigil/internal/taintremoval"
 	"github.com/nextdoor/vigil/pkg/config"
 )
+
+// Name of the leader election Lease. The probe reads this same Lease.
+const leaderElectionID = "vigil-controller.nextdoor.com"
 
 var (
 	scheme   = runtime.NewScheme()
@@ -110,6 +118,11 @@ func main() {
 		"max-concurrent-reconciles", cfg.MaxConcurrentReconciles,
 	)
 
+	// Set the lease namespace so the probe and the manager use the same Lease.
+	// POD_NAMESPACE comes from the downward API. If it's empty (local runs)
+	// the manager works out its own namespace and the probe just turns off.
+	leaderElectionNamespace := os.Getenv("POD_NAMESPACE")
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -118,7 +131,8 @@ func main() {
 		Cache:                         cacheopts.New(),
 		HealthProbeBindAddress:        probeAddr,
 		LeaderElection:                enableLeaderElection,
-		LeaderElectionID:              "vigil-controller.nextdoor.com",
+		LeaderElectionID:              leaderElectionID,
+		LeaderElectionNamespace:       leaderElectionNamespace,
 		LeaseDuration:                 &leaseDuration,
 		RenewDeadline:                 &renewDeadline,
 		RetryPeriod:                   &retryPeriod,
@@ -187,7 +201,11 @@ func main() {
 	// Logs warnings at escalating intervals so operators can detect stalled
 	// lease acquisition during rolling updates (see #21).
 	if enableLeaderElection {
-		go monitorLeaseAcquisition(mgr.Elected(), leaseDuration)
+		// A standby never gets elected, so its Elected() channel stays open.
+		// The probe lets it check if another replica holds the lease before
+		// warning. Uses the API reader so we don't need a cache for leases.
+		probe := newLeaseProbe(mgr.GetAPIReader(), leaderElectionNamespace, leaderElectionID, leaseDuration)
+		go monitorLeaseAcquisition(ctrl.Log.WithName("leader-election"), mgr.Elected(), leaseDuration, probe)
 	}
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
@@ -196,12 +214,54 @@ func main() {
 	}
 }
 
-// monitorLeaseAcquisition logs warnings when leader lease acquisition is
-// taking longer than expected. This surfaces leadership gaps caused by rapid
-// rolling updates where multiple ReplicaSet generations churn through lease
-// holders (see issue #21).
-func monitorLeaseAcquisition(elected <-chan struct{}, leaseDuration time.Duration) {
-	leaseLog := ctrl.Log.WithName("leader-election")
+// leaseProbe returns the lease holder and whether a leader is currently live.
+// A nil probe turns the check off and the monitor just uses elapsed time.
+type leaseProbe func(ctx context.Context) (holder string, live bool)
+
+// newLeaseProbe reads the lease through the API reader. Returns nil with no
+// namespace (local runs) so we don't read the wrong lease.
+func newLeaseProbe(reader client.Reader, namespace, name string, leaseDuration time.Duration) leaseProbe {
+	if namespace == "" {
+		return nil
+	}
+	key := types.NamespacedName{Namespace: namespace, Name: name}
+	return func(ctx context.Context) (string, bool) {
+		var lease coordinationv1.Lease
+		if err := reader.Get(ctx, key, &lease); err != nil {
+			return "", false
+		}
+		return leaderLeaseLive(&lease, time.Now(), leaseDuration)
+	}
+}
+
+// leaderLeaseLive is true when the lease has a holder and was renewed within
+// the last lease duration. Pure function so it's easy to test.
+func leaderLeaseLive(lease *coordinationv1.Lease, now time.Time, leaseDuration time.Duration) (string, bool) {
+	if lease == nil || lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity == "" {
+		return "", false
+	}
+	if lease.Spec.RenewTime == nil {
+		return "", false
+	}
+	if now.Sub(lease.Spec.RenewTime.Time) >= leaseDuration {
+		return *lease.Spec.HolderIdentity, false
+	}
+	return *lease.Spec.HolderIdentity, true
+}
+
+// monitorLeaseAcquisition warns when this replica takes too long to become
+// leader, which can happen during fast rolling updates (see issue #21).
+//
+// When a probe is set, it skips the warning if another replica already holds
+// the lease. A standby would otherwise warn forever even though the cluster is
+// fine (issue #70). We only escalate to ERROR when no leader is live at all,
+// which is the real stuck case from issue #55.
+func monitorLeaseAcquisition(
+	leaseLog logr.Logger,
+	elected <-chan struct{},
+	leaseDuration time.Duration,
+	probe leaseProbe,
+) {
 	start := time.Now()
 	warnInterval := 2 * leaseDuration
 	ticker := time.NewTicker(warnInterval)
@@ -218,6 +278,21 @@ func monitorLeaseAcquisition(elected <-chan struct{}, leaseDuration time.Duratio
 			return
 		case <-ticker.C:
 			elapsed := time.Since(start)
+
+			// If another replica is holding the lease we're just a standby,
+			// so log at debug and don't warn.
+			if probe != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), leaseDuration)
+				holder, live := probe(ctx)
+				cancel()
+				if live {
+					leaseLog.V(1).Info("standby replica; leader lease held by another replica",
+						"holder", holder,
+						"elapsed", elapsed.Round(time.Millisecond))
+					continue
+				}
+			}
+
 			if elapsed > 4*leaseDuration {
 				leaseLog.Error(nil, "leader lease acquisition is critically delayed — no controller is watching nodes",
 					"elapsed", elapsed.Round(time.Millisecond),

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -15,9 +15,60 @@
 package main
 
 import (
+	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/go-logr/logr"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func strPtr(s string) *string { return &s }
+
+// recordingSink is a log sink that remembers each entry so tests can check
+// whether something was logged as Info or Error.
+type recordingSink struct {
+	mu      sync.Mutex
+	entries []sinkEntry
+}
+
+type sinkEntry struct {
+	isError bool
+	msg     string
+}
+
+func (s *recordingSink) Init(logr.RuntimeInfo)          {}
+func (s *recordingSink) Enabled(int) bool               { return true }
+func (s *recordingSink) WithValues(...any) logr.LogSink { return s }
+func (s *recordingSink) WithName(string) logr.LogSink   { return s }
+
+func (s *recordingSink) Info(_ int, msg string, _ ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, sinkEntry{isError: false, msg: msg})
+}
+
+func (s *recordingSink) Error(_ error, msg string, _ ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, sinkEntry{isError: true, msg: msg})
+}
+
+func (s *recordingSink) errorCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, e := range s.entries {
+		if e.isError {
+			n++
+		}
+	}
+	return n
+}
 
 func TestMonitorLeaseAcquisition_FastAcquisition(t *testing.T) {
 	// Lease acquired before the warning interval — should return quickly
@@ -27,7 +78,7 @@ func TestMonitorLeaseAcquisition_FastAcquisition(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		monitorLeaseAcquisition(elected, 15*time.Second)
+		monitorLeaseAcquisition(logr.Discard(), elected, 15*time.Second, nil)
 		close(done)
 	}()
 
@@ -49,7 +100,7 @@ func TestMonitorLeaseAcquisition_DelayedAcquisition(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		monitorLeaseAcquisition(elected, leaseDuration)
+		monitorLeaseAcquisition(logr.Discard(), elected, leaseDuration, nil)
 		close(done)
 	}()
 
@@ -62,5 +113,148 @@ func TestMonitorLeaseAcquisition_DelayedAcquisition(t *testing.T) {
 		// Success
 	case <-time.After(time.Second):
 		t.Fatal("monitorLeaseAcquisition did not return after election signal")
+	}
+}
+
+func TestLeaderLeaseLive(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name       string
+		lease      *coordinationv1.Lease
+		wantHolder string
+		wantLive   bool
+	}{
+		{
+			name:     "nil lease",
+			lease:    nil,
+			wantLive: false,
+		},
+		{
+			name:     "no holder identity",
+			lease:    &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{RenewTime: &metav1.MicroTime{Time: now}}},
+			wantLive: false,
+		},
+		{
+			name:     "no renew time",
+			lease:    &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{HolderIdentity: strPtr("pod-a")}},
+			wantLive: false,
+		},
+		{
+			name: "freshly renewed by another holder",
+			lease: &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{
+				HolderIdentity: strPtr("pod-a"),
+				RenewTime:      &metav1.MicroTime{Time: now.Add(-2 * time.Second)},
+			}},
+			wantHolder: "pod-a",
+			wantLive:   true,
+		},
+		{
+			name: "stale renewal, leader is dead",
+			lease: &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{
+				HolderIdentity: strPtr("pod-a"),
+				RenewTime:      &metav1.MicroTime{Time: now.Add(-30 * time.Second)},
+			}},
+			wantHolder: "pod-a",
+			wantLive:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			holder, live := leaderLeaseLive(tt.lease, now, 15*time.Second)
+			if live != tt.wantLive {
+				t.Errorf("live = %v, want %v", live, tt.wantLive)
+			}
+			if holder != tt.wantHolder {
+				t.Errorf("holder = %q, want %q", holder, tt.wantHolder)
+			}
+		})
+	}
+}
+
+// A standby that never gets elected should not log an ERROR while another
+// replica is the leader (issue #70).
+func TestMonitorLeaseAcquisition_HealthyStandby(t *testing.T) {
+	sink := &recordingSink{}
+
+	var probeCalls atomic.Int32
+	probe := func(context.Context) (string, bool) {
+		probeCalls.Add(1)
+		return "leader-pod", true // another replica is the leader
+	}
+
+	elected := make(chan struct{}) // never closes, so we stay a standby
+	leaseDuration := 10 * time.Millisecond
+	done := make(chan struct{})
+	go func() {
+		monitorLeaseAcquisition(logr.New(sink), elected, leaseDuration, probe)
+		close(done)
+	}()
+
+	// Wait long enough that the old code would have logged an ERROR.
+	time.Sleep(120 * time.Millisecond)
+
+	if probeCalls.Load() == 0 {
+		t.Fatal("probe was never consulted")
+	}
+	if n := sink.errorCount(); n != 0 {
+		t.Fatalf("healthy standby emitted %d ERROR log(s), want 0", n)
+	}
+}
+
+// When no leader is live the monitor should still log an ERROR, so we don't
+// lose the stuck-cluster check from issue #55.
+func TestMonitorLeaseAcquisition_NoLiveLeader(t *testing.T) {
+	sink := &recordingSink{}
+
+	probe := func(context.Context) (string, bool) {
+		return "", false // no live leader
+	}
+
+	elected := make(chan struct{})
+	leaseDuration := 10 * time.Millisecond
+	done := make(chan struct{})
+	go func() {
+		monitorLeaseAcquisition(logr.New(sink), elected, leaseDuration, probe)
+		close(done)
+	}()
+
+	// After 40ms (4 lease durations) the monitor should log an ERROR.
+	time.Sleep(120 * time.Millisecond)
+
+	if n := sink.errorCount(); n == 0 {
+		t.Fatal("no-live-leader case did not emit any ERROR log")
+	}
+}
+
+// End to end through the real probe: a stale lease (held by a dead pod) should
+// still produce the ERROR, which is the stuck case from issue #55.
+func TestMonitorLeaseAcquisition_StaleLease(t *testing.T) {
+	namespace := "vigil-system"
+	leaseDuration := 10 * time.Millisecond
+
+	// A lease whose last renewal is way older than the lease duration.
+	staleLease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: leaderElectionID},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity: strPtr("dead-pod"),
+			RenewTime:      &metav1.MicroTime{Time: time.Now().Add(-time.Minute)},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(staleLease).Build()
+	probe := newLeaseProbe(c, namespace, leaderElectionID, leaseDuration)
+
+	sink := &recordingSink{}
+	elected := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		monitorLeaseAcquisition(logr.New(sink), elected, leaseDuration, probe)
+		close(done)
+	}()
+
+	time.Sleep(120 * time.Millisecond)
+
+	if n := sink.errorCount(); n == 0 {
+		t.Fatal("stale lease did not emit any ERROR log")
 	}
 }


### PR DESCRIPTION
In HA (leader election on, 2+ replicas), the non-leader replica logged "no controller is watching nodes" at ERROR every 2x leaseDuration forever, even with a healthy leader. The monitor only watched its own Elected() channel, which never fires on a standby, so it could not tell "another pod is leading" (fine) from "nobody is leading" (the real #55 wedge).

monitorLeaseAcquisition now reads the election Lease before escalating. If another replica holds it and renewed within the lease duration, this pod is a standby and logs at debug instead of warning. ERROR is reserved for when no leader is live, preserving #55 detection.

The lease namespace is pinned to POD_NAMESPACE (downward API) so the probe and the manager read the same Lease.

Tests: healthy standby -> no ERROR; no live leader -> ERROR; a stale lease fed through the real probe -> ERROR (#55 end to end); leaderLeaseLive table.

Fixes #70