### PR TITLE
feat(metrics): expose cluster-wide DaemonSet gauges so an idle vigil is not "no data"

### DIFF
--- a/internal/controller/node_readiness_controller.go
+++ b/internal/controller/node_readiness_controller.go
@@ -89,6 +89,10 @@ func (r *NodeReadinessReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	// Count the node as waiting now: discovery below can fail, and a tainted
+	// node vigil cannot evaluate must not read as no node at all.
+	metrics.TrackNode(node.Name)
+
 	nodeAge := time.Since(node.CreationTimestamp.Time).Round(time.Second)
 
 	// Check for timeout before doing discovery.

--- a/internal/controller/node_readiness_controller.go
+++ b/internal/controller/node_readiness_controller.go
@@ -74,7 +74,7 @@ func (r *NodeReadinessReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := r.Get(ctx, req.NamespacedName, &node); err != nil {
 		// Node is gone: stop tracking it.
 		if apierrors.IsNotFound(err) {
-			cleanupNodeMetrics(req.Name)
+			metrics.ForgetNode(req.Name)
 			r.nodeState.remove(req.Name)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -84,7 +84,7 @@ func (r *NodeReadinessReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if !hasTaint(&node, r.Config.TaintKey) {
 		// Taint is gone: stop tracking the node. Our own removal patch
 		// triggers a node update event, so this also runs after removals.
-		cleanupNodeMetrics(node.Name)
+		metrics.ForgetNode(node.Name)
 		r.nodeState.remove(node.Name)
 		return ctrl.Result{}, nil
 	}
@@ -101,7 +101,7 @@ func (r *NodeReadinessReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("discovering expected daemonsets: %w", err)
 	}
 
-	metrics.ExpectedDaemonSets.WithLabelValues(node.Name).Set(float64(len(expectedDS)))
+	metrics.SetNodeExpected(node.Name, len(expectedDS))
 
 	// Check pod readiness for each expected DaemonSet.
 	statuses, err := r.Readiness.CheckNode(ctx, node.Name, expectedDS)
@@ -111,7 +111,7 @@ func (r *NodeReadinessReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	readyCount := readiness.CountReady(statuses)
-	metrics.ReadyDaemonSets.WithLabelValues(node.Name).Set(float64(readyCount))
+	metrics.SetNodeReady(node.Name, readyCount)
 
 	if readyCount == len(expectedDS) {
 		log.Info("node ready, removing taint",
@@ -289,13 +289,6 @@ func (r *NodeReadinessReconciler) podToNode(_ context.Context, o client.Object) 
 	return []reconcile.Request{
 		{NamespacedName: types.NamespacedName{Name: pod.Spec.NodeName}},
 	}
-}
-
-// cleanupNodeMetrics drops the per-node metric series for a node that is no
-// longer tracked, keeping cardinality bounded as nodes churn.
-func cleanupNodeMetrics(nodeName string) {
-	metrics.ExpectedDaemonSets.DeleteLabelValues(nodeName)
-	metrics.ReadyDaemonSets.DeleteLabelValues(nodeName)
 }
 
 // hasTaint returns true if the node has a taint with the given key.

--- a/internal/controller/node_readiness_controller_test.go
+++ b/internal/controller/node_readiness_controller_test.go
@@ -80,10 +80,11 @@ func TestReconcile_NodeWithoutTaint(t *testing.T) {
 	// must clean it up.
 	r.initNodeState()
 	r.nodeState.observe("test-node", 1, 0)
-	metrics.ExpectedDaemonSets.WithLabelValues("test-node").Set(1)
-	metrics.ReadyDaemonSets.WithLabelValues("test-node").Set(0)
+	metrics.SetNodeExpected("test-node", 1)
+	metrics.SetNodeReady("test-node", 0)
 	expectedBefore := promtestutil.CollectAndCount(metrics.ExpectedDaemonSets)
 	readyBefore := promtestutil.CollectAndCount(metrics.ReadyDaemonSets)
+	aggExpectedBefore := promtestutil.ToFloat64(metrics.TrackedExpectedDaemonSets)
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test-node"},
@@ -95,6 +96,8 @@ func TestReconcile_NodeWithoutTaint(t *testing.T) {
 		"expected-daemonsets series should be deleted")
 	assert.Equal(t, readyBefore-1, promtestutil.CollectAndCount(metrics.ReadyDaemonSets),
 		"ready-daemonsets series should be deleted")
+	assert.Equal(t, aggExpectedBefore-1, promtestutil.ToFloat64(metrics.TrackedExpectedDaemonSets),
+		"node should stop contributing to the aggregate gauge")
 	_, tracked := r.nodeState.nodes["test-node"]
 	assert.False(t, tracked, "nodeState entry should be removed")
 }
@@ -264,11 +267,23 @@ func TestReconcile_NodeWithTaint_NotReady_Requeues(t *testing.T) {
 
 	r := newReconciler(cl, scheme, cfg)
 
+	// The gauges are process-global, so measure this node's contribution as a
+	// delta from a known-clean baseline.
+	metrics.ForgetNode("test-node")
+	aggExpectedBefore := promtestutil.ToFloat64(metrics.TrackedExpectedDaemonSets)
+	aggReadyBefore := promtestutil.ToFloat64(metrics.TrackedReadyDaemonSets)
+	t.Cleanup(func() { metrics.ForgetNode("test-node") })
+
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test-node"},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 5*time.Second, result.RequeueAfter)
+
+	assert.Equal(t, aggExpectedBefore+1, promtestutil.ToFloat64(metrics.TrackedExpectedDaemonSets),
+		"a still-tracked node should contribute its expected count to the aggregate")
+	assert.Equal(t, aggReadyBefore, promtestutil.ToFloat64(metrics.TrackedReadyDaemonSets),
+		"a Pending pod should contribute nothing to the ready aggregate")
 }
 
 func TestReconcile_CatchupMetric_OldNode(t *testing.T) {
@@ -436,10 +451,11 @@ func TestReconcile_NodeNotFound(t *testing.T) {
 	// must clean it up.
 	r.initNodeState()
 	r.nodeState.observe("nonexistent", 1, 0)
-	metrics.ExpectedDaemonSets.WithLabelValues("nonexistent").Set(1)
-	metrics.ReadyDaemonSets.WithLabelValues("nonexistent").Set(0)
+	metrics.SetNodeExpected("nonexistent", 1)
+	metrics.SetNodeReady("nonexistent", 0)
 	expectedBefore := promtestutil.CollectAndCount(metrics.ExpectedDaemonSets)
 	readyBefore := promtestutil.CollectAndCount(metrics.ReadyDaemonSets)
+	aggExpectedBefore := promtestutil.ToFloat64(metrics.TrackedExpectedDaemonSets)
 
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "nonexistent"},
@@ -451,6 +467,8 @@ func TestReconcile_NodeNotFound(t *testing.T) {
 		"expected-daemonsets series should be deleted")
 	assert.Equal(t, readyBefore-1, promtestutil.CollectAndCount(metrics.ReadyDaemonSets),
 		"ready-daemonsets series should be deleted")
+	assert.Equal(t, aggExpectedBefore-1, promtestutil.ToFloat64(metrics.TrackedExpectedDaemonSets),
+		"node should stop contributing to the aggregate gauge")
 	_, tracked := r.nodeState.nodes["nonexistent"]
 	assert.False(t, tracked, "nodeState entry should be removed")
 }

--- a/internal/controller/node_readiness_controller_test.go
+++ b/internal/controller/node_readiness_controller_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -284,6 +285,62 @@ func TestReconcile_NodeWithTaint_NotReady_Requeues(t *testing.T) {
 		"a still-tracked node should contribute its expected count to the aggregate")
 	assert.Equal(t, aggReadyBefore, promtestutil.ToFloat64(metrics.TrackedReadyDaemonSets),
 		"a Pending pod should contribute nothing to the ready aggregate")
+}
+
+// failingReader fails DaemonSet discovery. Discovery only ever calls List, so
+// the embedded nil Reader is enough to satisfy the interface.
+type failingReader struct {
+	client.Reader
+}
+
+func (failingReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return errors.New("apiserver unavailable")
+}
+
+// TestReconcile_DiscoveryFails_NodeStillCounted pins why TrackNode runs before
+// discovery: a tainted node vigil cannot evaluate must still show up in
+// vigil_tainted_nodes, rather than leaving the gauge at 0 and looking idle.
+func TestReconcile_DiscoveryFails_NodeStillCounted(t *testing.T) {
+	scheme := newTestScheme()
+	cfg := config.NewDefault()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-node",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: cfg.TaintKey, Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(node).
+		WithIndex(&corev1.Pod{}, readiness.NodeNameField, func(o client.Object) []string {
+			return []string{o.(*corev1.Pod).Spec.NodeName}
+		}).
+		Build()
+
+	r := newReconciler(cl, scheme, cfg)
+	r.Discovery = discovery.New(failingReader{}, logr.Discard(), cfg)
+
+	// The gauges are process-global, so measure from a known-clean baseline.
+	metrics.ForgetNode("test-node")
+	taintedBefore := promtestutil.ToFloat64(metrics.TaintedNodes)
+	seriesBefore := promtestutil.CollectAndCount(metrics.ExpectedDaemonSets)
+	t.Cleanup(func() { metrics.ForgetNode("test-node") })
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-node"},
+	})
+	require.Error(t, err, "a discovery failure should surface as a reconcile error")
+
+	assert.Equal(t, taintedBefore+1, promtestutil.ToFloat64(metrics.TaintedNodes),
+		"a tainted node must be counted even when discovery fails")
+	assert.Equal(t, seriesBefore, promtestutil.CollectAndCount(metrics.ExpectedDaemonSets),
+		"no per-node series when the expected count was never learned")
 }
 
 func TestReconcile_CatchupMetric_OldNode(t *testing.T) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -63,6 +63,21 @@ var (
 		Help: "Number of Ready DaemonSet pods per node.",
 	}, []string{"node"})
 
+	// TrackedExpectedDaemonSets is ExpectedDaemonSets summed across every
+	// tracked node. Unlabeled, so it is exposed from process start rather than
+	// appearing only once a node is tracked — see the note on nodeAggregate.
+	TrackedExpectedDaemonSets = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "vigil_tracked_expected_daemonsets",
+		Help: "Expected DaemonSets summed across all nodes currently waiting for DaemonSet readiness.",
+	})
+
+	// TrackedReadyDaemonSets is ReadyDaemonSets summed across every tracked
+	// node. Unlabeled for the same reason as TrackedExpectedDaemonSets.
+	TrackedReadyDaemonSets = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "vigil_tracked_ready_daemonsets",
+		Help: "Ready DaemonSet pods summed across all nodes currently waiting for DaemonSet readiness.",
+	})
+
 	// DiscoveryDuration tracks the time to evaluate DaemonSet scheduling rules.
 	DiscoveryDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "vigil_discovery_duration_seconds",
@@ -94,6 +109,8 @@ func init() {
 		ReconcileErrors,
 		ExpectedDaemonSets,
 		ReadyDaemonSets,
+		TrackedExpectedDaemonSets,
+		TrackedReadyDaemonSets,
 		DiscoveryDuration,
 		TimeoutBlockingDaemonSet,
 		LeadershipCatchupNodes,

--- a/pkg/metrics/nodes.go
+++ b/pkg/metrics/nodes.go
@@ -28,8 +28,16 @@ import "sync"
 // and report 0 while idle.
 //
 // The map is the single source of truth for both, so the aggregates cannot
-// drift from the per-node series they summarize. It also backs TaintedNodes,
-// which is the same aggregate expressed as a node count.
+// drift from the per-node series they summarize. It also backs TaintedNodes:
+// note that a node admitted by TrackNode counts there while contributing 0 to
+// both sums, so the two are not interchangeable during a discovery outage.
+//
+// mu guards the per-node series as well as the map, which serializes writers
+// and keeps the two from diverging permanently under concurrent updates to the
+// same node. It does not make a scrape atomic: Gather collects the vec and the
+// aggregate gauges separately without taking this lock, so a scrape landing
+// mid-update can still see them one update apart. That skew self-corrects on
+// the next write; a permanently wrong aggregate would not.
 type nodeAggregate struct {
 	mu    sync.Mutex
 	nodes map[string]nodeCounts
@@ -42,12 +50,31 @@ type nodeCounts struct {
 
 var trackedNodes = &nodeAggregate{nodes: make(map[string]nodeCounts)}
 
-// SetNodeExpected records the expected-DaemonSet count for a tracked node.
-func SetNodeExpected(nodeName string, expected int) {
-	ExpectedDaemonSets.WithLabelValues(nodeName).Set(float64(expected))
-
+// TrackNode records that vigil is waiting on a node, before its DaemonSet
+// counts are known. Discovery runs after this point and can fail, so admitting
+// the node here is what keeps TaintedNodes reporting it through a discovery
+// outage instead of reading 0 for nodes that are still tainted.
+//
+// No per-node series is created: an expected count of 0 would be indexed as
+// "nothing to wait for" rather than "not yet known". Until discovery reports,
+// the node counts towards TaintedNodes and contributes 0 to the sums.
+func TrackNode(nodeName string) {
 	trackedNodes.mu.Lock()
 	defer trackedNodes.mu.Unlock()
+
+	if _, ok := trackedNodes.nodes[nodeName]; ok {
+		return
+	}
+	trackedNodes.nodes[nodeName] = nodeCounts{}
+	trackedNodes.publishLocked()
+}
+
+// SetNodeExpected records the expected-DaemonSet count for a tracked node.
+func SetNodeExpected(nodeName string, expected int) {
+	trackedNodes.mu.Lock()
+	defer trackedNodes.mu.Unlock()
+
+	ExpectedDaemonSets.WithLabelValues(nodeName).Set(float64(expected))
 	c := trackedNodes.nodes[nodeName]
 	c.expected = expected
 	trackedNodes.nodes[nodeName] = c
@@ -56,10 +83,10 @@ func SetNodeExpected(nodeName string, expected int) {
 
 // SetNodeReady records the Ready-DaemonSet-pod count for a tracked node.
 func SetNodeReady(nodeName string, ready int) {
-	ReadyDaemonSets.WithLabelValues(nodeName).Set(float64(ready))
-
 	trackedNodes.mu.Lock()
 	defer trackedNodes.mu.Unlock()
+
+	ReadyDaemonSets.WithLabelValues(nodeName).Set(float64(ready))
 	c := trackedNodes.nodes[nodeName]
 	c.ready = ready
 	trackedNodes.nodes[nodeName] = c
@@ -69,11 +96,11 @@ func SetNodeReady(nodeName string, ready int) {
 // ForgetNode drops a node from the per-node series and the aggregates once it
 // is no longer tracked, keeping per-node cardinality bounded under churn.
 func ForgetNode(nodeName string) {
-	ExpectedDaemonSets.DeleteLabelValues(nodeName)
-	ReadyDaemonSets.DeleteLabelValues(nodeName)
-
 	trackedNodes.mu.Lock()
 	defer trackedNodes.mu.Unlock()
+
+	ExpectedDaemonSets.DeleteLabelValues(nodeName)
+	ReadyDaemonSets.DeleteLabelValues(nodeName)
 	delete(trackedNodes.nodes, nodeName)
 	trackedNodes.publishLocked()
 }

--- a/pkg/metrics/nodes.go
+++ b/pkg/metrics/nodes.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Nextdoor, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import "sync"
+
+// nodeAggregate holds the per-node DaemonSet counts that back the unlabeled
+// aggregate gauges.
+//
+// Why the aggregates exist: client_golang omits a label-vec with zero children
+// from the exposition entirely — no samples, no HELP, no TYPE. On a low-churn
+// cluster with nothing currently tainted, vigil_expected_daemonsets and
+// vigil_ready_daemonsets are therefore absent from /metrics, so dashboards read
+// "no data" and a healthy-but-idle vigil looks identical to a broken one. The
+// unlabeled aggregates have no such hole: they are registered at process start
+// and report 0 while idle.
+//
+// The map is the single source of truth for both, so the aggregates cannot
+// drift from the per-node series they summarize.
+type nodeAggregate struct {
+	mu    sync.Mutex
+	nodes map[string]nodeCounts
+}
+
+type nodeCounts struct {
+	expected int
+	ready    int
+}
+
+var trackedNodes = &nodeAggregate{nodes: make(map[string]nodeCounts)}
+
+// SetNodeExpected records the expected-DaemonSet count for a tracked node.
+func SetNodeExpected(nodeName string, expected int) {
+	ExpectedDaemonSets.WithLabelValues(nodeName).Set(float64(expected))
+
+	trackedNodes.mu.Lock()
+	defer trackedNodes.mu.Unlock()
+	c := trackedNodes.nodes[nodeName]
+	c.expected = expected
+	trackedNodes.nodes[nodeName] = c
+	trackedNodes.publishLocked()
+}
+
+// SetNodeReady records the Ready-DaemonSet-pod count for a tracked node.
+func SetNodeReady(nodeName string, ready int) {
+	ReadyDaemonSets.WithLabelValues(nodeName).Set(float64(ready))
+
+	trackedNodes.mu.Lock()
+	defer trackedNodes.mu.Unlock()
+	c := trackedNodes.nodes[nodeName]
+	c.ready = ready
+	trackedNodes.nodes[nodeName] = c
+	trackedNodes.publishLocked()
+}
+
+// ForgetNode drops a node from the per-node series and the aggregates once it
+// is no longer tracked, keeping per-node cardinality bounded under churn.
+func ForgetNode(nodeName string) {
+	ExpectedDaemonSets.DeleteLabelValues(nodeName)
+	ReadyDaemonSets.DeleteLabelValues(nodeName)
+
+	trackedNodes.mu.Lock()
+	defer trackedNodes.mu.Unlock()
+	delete(trackedNodes.nodes, nodeName)
+	trackedNodes.publishLocked()
+}
+
+// publishLocked recomputes the aggregate gauges from the tracked node set. The
+// set is bounded by the number of concurrently-tainted nodes, so summing on
+// every update is cheaper than the bookkeeping needed to maintain running
+// totals correctly across partial updates. Caller must hold mu.
+func (a *nodeAggregate) publishLocked() {
+	var expected, ready int
+	for _, c := range a.nodes {
+		expected += c.expected
+		ready += c.ready
+	}
+	TrackedExpectedDaemonSets.Set(float64(expected))
+	TrackedReadyDaemonSets.Set(float64(ready))
+}

--- a/pkg/metrics/nodes.go
+++ b/pkg/metrics/nodes.go
@@ -28,7 +28,8 @@ import "sync"
 // and report 0 while idle.
 //
 // The map is the single source of truth for both, so the aggregates cannot
-// drift from the per-node series they summarize.
+// drift from the per-node series they summarize. It also backs TaintedNodes,
+// which is the same aggregate expressed as a node count.
 type nodeAggregate struct {
 	mu    sync.Mutex
 	nodes map[string]nodeCounts
@@ -87,6 +88,7 @@ func (a *nodeAggregate) publishLocked() {
 		expected += c.expected
 		ready += c.ready
 	}
+	TaintedNodes.Set(float64(len(a.nodes)))
 	TrackedExpectedDaemonSets.Set(float64(expected))
 	TrackedReadyDaemonSets.Set(float64(ready))
 }

--- a/pkg/metrics/nodes_test.go
+++ b/pkg/metrics/nodes_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Nextdoor, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// reset clears tracked state between tests. The gauges are package-level, so
+// tests here must not run in parallel with each other.
+func reset(t *testing.T) {
+	t.Helper()
+	trackedNodes.mu.Lock()
+	ExpectedDaemonSets.Reset()
+	ReadyDaemonSets.Reset()
+	trackedNodes.nodes = make(map[string]nodeCounts)
+	trackedNodes.publishLocked()
+	trackedNodes.mu.Unlock()
+}
+
+// TestAggregateGaugesExposedWhenIdle is the acceptance check for the "no data
+// vs. broken" ambiguity: with nothing tracked, the per-node vecs contribute
+// nothing to the exposition, but the aggregates must still be scrapeable at 0.
+func TestAggregateGaugesExposedWhenIdle(t *testing.T) {
+	reset(t)
+
+	families, err := ctrlmetrics.Registry.Gather()
+	require.NoError(t, err)
+
+	names := make(map[string]bool, len(families))
+	for _, f := range families {
+		names[f.GetName()] = true
+	}
+
+	assert.True(t, names["vigil_tracked_expected_daemonsets"],
+		"aggregate gauge must be exposed with no nodes tracked")
+	assert.True(t, names["vigil_tracked_ready_daemonsets"],
+		"aggregate gauge must be exposed with no nodes tracked")
+
+	// The per-node vecs are absent while empty — the behavior the aggregates
+	// exist to compensate for. Asserted so a future change to client_golang's
+	// empty-vec handling surfaces here rather than silently making the
+	// aggregates redundant.
+	assert.False(t, names["vigil_expected_daemonsets"],
+		"empty per-node vec is omitted from the exposition")
+	assert.False(t, names["vigil_ready_daemonsets"],
+		"empty per-node vec is omitted from the exposition")
+
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets))
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+}
+
+func TestAggregateGaugesSumAcrossNodes(t *testing.T) {
+	reset(t)
+
+	SetNodeExpected("node-a", 5)
+	SetNodeReady("node-a", 3)
+	SetNodeExpected("node-b", 4)
+	SetNodeReady("node-b", 4)
+
+	assert.Equal(t, 9.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets))
+	assert.Equal(t, 7.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+
+	// Per-node series stay in place alongside the aggregates.
+	assert.Equal(t, 5.0, promtestutil.ToFloat64(ExpectedDaemonSets.WithLabelValues("node-a")))
+	assert.Equal(t, 4.0, promtestutil.ToFloat64(ReadyDaemonSets.WithLabelValues("node-b")))
+}
+
+func TestSetNodeExpectedBeforeReady(t *testing.T) {
+	reset(t)
+
+	// The reconciler learns the expected count before the ready count, and
+	// bails out between the two if the readiness check errors. The half-updated
+	// node must still contribute its expected count.
+	SetNodeExpected("node-a", 6)
+
+	assert.Equal(t, 6.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets))
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+}
+
+func TestSetNodeOverwritesPreviousCounts(t *testing.T) {
+	reset(t)
+
+	SetNodeExpected("node-a", 5)
+	SetNodeReady("node-a", 1)
+	SetNodeReady("node-a", 4)
+
+	assert.Equal(t, 5.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets),
+		"expected count must not accumulate across updates")
+	assert.Equal(t, 4.0, promtestutil.ToFloat64(TrackedReadyDaemonSets),
+		"ready count must replace, not add to, the previous value")
+}
+
+func TestForgetNodeDropsSeriesAndAggregate(t *testing.T) {
+	reset(t)
+
+	SetNodeExpected("node-a", 5)
+	SetNodeReady("node-a", 3)
+	SetNodeExpected("node-b", 4)
+	SetNodeReady("node-b", 2)
+
+	ForgetNode("node-a")
+
+	assert.Equal(t, 4.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets),
+		"forgotten node must stop contributing to the aggregate")
+	assert.Equal(t, 2.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+	assert.Equal(t, 1, promtestutil.CollectAndCount(ExpectedDaemonSets),
+		"only node-b's per-node series should remain")
+
+	ForgetNode("node-b")
+
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets))
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+	assert.Equal(t, 0, promtestutil.CollectAndCount(ExpectedDaemonSets))
+	assert.Equal(t, 0, promtestutil.CollectAndCount(ReadyDaemonSets))
+}
+
+func TestForgetNodeUnknownNodeIsNoop(t *testing.T) {
+	reset(t)
+
+	SetNodeExpected("node-a", 5)
+	SetNodeReady("node-a", 3)
+
+	ForgetNode("never-tracked")
+
+	assert.Equal(t, 5.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets))
+	assert.Equal(t, 3.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+}
+
+// TestAggregateGaugeExposition pins the wire format. The gauge type matters:
+// a "_total"-style counter suffix would have made these look like counters to
+// PromQL and to promlint.
+func TestAggregateGaugeExposition(t *testing.T) {
+	reset(t)
+
+	SetNodeExpected("node-a", 2)
+	SetNodeReady("node-a", 1)
+
+	expected := `
+# HELP vigil_tracked_expected_daemonsets Expected DaemonSets summed across all nodes currently waiting for DaemonSet readiness.
+# TYPE vigil_tracked_expected_daemonsets gauge
+vigil_tracked_expected_daemonsets 2
+`
+	require.NoError(t, promtestutil.CollectAndCompare(
+		TrackedExpectedDaemonSets, strings.NewReader(expected)))
+}
+
+// TestConcurrentUpdates guards the aggregate arithmetic under the reconciler's
+// concurrent workers (MaxConcurrentReconciles defaults to 10).
+func TestConcurrentUpdates(t *testing.T) {
+	reset(t)
+
+	const nodes = 50
+	var wg sync.WaitGroup
+	for i := range nodes {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := fmt.Sprintf("node-%d", i)
+			SetNodeExpected(name, 2)
+			SetNodeReady(name, 1)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, float64(nodes*2), promtestutil.ToFloat64(TrackedExpectedDaemonSets))
+	assert.Equal(t, float64(nodes), promtestutil.ToFloat64(TrackedReadyDaemonSets))
+}

--- a/pkg/metrics/nodes_test.go
+++ b/pkg/metrics/nodes_test.go
@@ -93,6 +93,37 @@ func TestTaintedNodesCountsTrackedNodes(t *testing.T) {
 	assert.Equal(t, 0.0, promtestutil.ToFloat64(TaintedNodes))
 }
 
+// TestTrackNodeCountsNodeBeforeDiscovery covers the discovery-failure window:
+// the reconciler admits the node, then bails out before either count is known.
+func TestTrackNodeCountsNodeBeforeDiscovery(t *testing.T) {
+	reset(t)
+
+	TrackNode("node-a")
+
+	assert.Equal(t, 1.0, promtestutil.ToFloat64(TaintedNodes),
+		"a tainted node must be counted before its DaemonSet counts are known")
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets))
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+	assert.Equal(t, 0, promtestutil.CollectAndCount(ExpectedDaemonSets),
+		"no per-node series until discovery reports a count")
+	assert.Equal(t, 0, promtestutil.CollectAndCount(ReadyDaemonSets))
+}
+
+func TestTrackNodeKeepsExistingCounts(t *testing.T) {
+	reset(t)
+
+	SetNodeExpected("node-a", 5)
+	SetNodeReady("node-a", 3)
+
+	// Every reconcile of a still-tainted node calls TrackNode again.
+	TrackNode("node-a")
+
+	assert.Equal(t, 5.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets),
+		"re-tracking a known node must not reset its counts")
+	assert.Equal(t, 3.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+	assert.Equal(t, 1.0, promtestutil.ToFloat64(TaintedNodes))
+}
+
 func TestAggregateGaugesSumAcrossNodes(t *testing.T) {
 	reset(t)
 

--- a/pkg/metrics/nodes_test.go
+++ b/pkg/metrics/nodes_test.go
@@ -179,11 +179,13 @@ func TestAggregateGaugeExposition(t *testing.T) {
 	SetNodeExpected("node-a", 2)
 	SetNodeReady("node-a", 1)
 
-	expected := `
-# HELP vigil_tracked_expected_daemonsets Expected DaemonSets summed across all nodes currently waiting for DaemonSet readiness.
-# TYPE vigil_tracked_expected_daemonsets gauge
-vigil_tracked_expected_daemonsets 2
-`
+	// Assembled rather than written as one raw string: the HELP line exceeds the
+	// 120-column limit, and the exposition format will not let it wrap.
+	expected := "\n# HELP vigil_tracked_expected_daemonsets Expected DaemonSets summed" +
+		" across all nodes currently waiting for DaemonSet readiness.\n" +
+		"# TYPE vigil_tracked_expected_daemonsets gauge\n" +
+		"vigil_tracked_expected_daemonsets 2\n"
+
 	require.NoError(t, promtestutil.CollectAndCompare(
 		TrackedExpectedDaemonSets, strings.NewReader(expected)))
 }

--- a/pkg/metrics/nodes_test.go
+++ b/pkg/metrics/nodes_test.go
@@ -68,6 +68,29 @@ func TestAggregateGaugesExposedWhenIdle(t *testing.T) {
 
 	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets))
 	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TaintedNodes))
+}
+
+func TestTaintedNodesCountsTrackedNodes(t *testing.T) {
+	reset(t)
+
+	SetNodeExpected("node-a", 5)
+	assert.Equal(t, 1.0, promtestutil.ToFloat64(TaintedNodes),
+		"a node becomes counted as soon as its first count is recorded")
+
+	SetNodeReady("node-a", 2)
+	assert.Equal(t, 1.0, promtestutil.ToFloat64(TaintedNodes),
+		"a second update to the same node must not double-count it")
+
+	SetNodeExpected("node-b", 3)
+	SetNodeReady("node-b", 3)
+	assert.Equal(t, 2.0, promtestutil.ToFloat64(TaintedNodes))
+
+	ForgetNode("node-a")
+	assert.Equal(t, 1.0, promtestutil.ToFloat64(TaintedNodes))
+
+	ForgetNode("node-b")
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TaintedNodes))
 }
 
 func TestAggregateGaugesSumAcrossNodes(t *testing.T) {

--- a/test/e2e/node_readiness_test.go
+++ b/test/e2e/node_readiness_test.go
@@ -121,6 +121,20 @@ var _ = Describe("Node Readiness Controller", Ordered, func() {
 			By("Verifying no restarts over 10 second window")
 			waitAndCheckNoRestarts(ctx, restarts, 10*time.Second)
 		})
+
+		// Runs before any taint is applied, so this is the idle case: no node is
+		// tracked, the per-node vecs are empty and therefore absent from the
+		// exposition. The aggregates must still be scrapeable, otherwise a
+		// dashboard cannot tell an idle vigil from a broken one.
+		It("should expose aggregate DaemonSet gauges while idle", func() {
+			By("Fetching /metrics with no tainted nodes")
+			metricsBody := getMetrics(ctx)
+
+			Expect(metricsBody).To(ContainSubstring("vigil_tracked_expected_daemonsets 0"),
+				"aggregate expected-daemonsets gauge should report 0 while idle")
+			Expect(metricsBody).To(ContainSubstring("vigil_tracked_ready_daemonsets 0"),
+				"aggregate ready-daemonsets gauge should report 0 while idle")
+		})
 	})
 
 	Context("taint detection and readiness evaluation", func() {
@@ -204,6 +218,14 @@ var _ = Describe("Node Readiness Controller", Ordered, func() {
 
 			Expect(metricsBody).NotTo(ContainSubstring(`vigil_ready_daemonsets{node=`),
 				"per-node ready-daemonsets series should be deleted after taint removal")
+
+			By("Checking aggregate gauges survive the per-node cleanup at 0")
+			// The aggregates are unlabeled, so unlike the per-node series they
+			// stay in the exposition once the node is untracked.
+			Expect(metricsBody).To(ContainSubstring("vigil_tracked_expected_daemonsets 0"),
+				"aggregate expected-daemonsets gauge should return to 0, not disappear")
+			Expect(metricsBody).To(ContainSubstring("vigil_tracked_ready_daemonsets 0"),
+				"aggregate ready-daemonsets gauge should return to 0, not disappear")
 
 			By("Checking for vigil_successful_removals_total metric")
 			Expect(metricsBody).To(ContainSubstring("vigil_successful_removals_total"),

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -33,10 +33,11 @@ Dashboards built on the per-node gauges therefore read **no data** whenever
 nothing is tainted, which is indistinguishable from a broken or absent
 controller.
 
-Use the unlabeled `vigil_tracked_*` aggregates for dashboard panels and alerts.
-They are registered at process start, report `0` while idle, and never drop out
-of the exposition. Reach for the per-node series when drilling into which
-specific node is stuck.
+Use the unlabeled `vigil_tracked_*` aggregates — and `vigil_tainted_nodes`, the
+same aggregate expressed as a node count — for dashboard panels and alerts. They
+are registered at process start, report `0` while idle, and never drop out of the
+exposition. Reach for the per-node series when drilling into which specific node
+is stuck.
 
 ```promql
 # Nodes waiting, and how far along they are — always plots, even when idle.

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -23,28 +23,54 @@ weight: 20
 ## Per-node vs. aggregate gauges
 
 The per-node gauges carry a `node` label and exist only while vigil is tracking
-that node — from the reconcile that first sees the startup taint until the taint
-is gone or the node is deleted. This keeps cardinality bounded under node churn,
-but it means that on an idle cluster the label-vec is empty, and the Prometheus
-client omits an empty label-vec from `/metrics` entirely: no samples, no `HELP`,
-no `TYPE`.
+that node, disappearing once the taint is gone or the node is deleted. They also
+start late, and not together: `vigil_expected_daemonsets` appears once DaemonSet
+discovery reports a count, and `vigil_ready_daemonsets` only after a readiness
+check succeeds — so a node whose readiness check keeps failing has an expected
+series and no ready series at all.
+
+This keeps cardinality bounded under node churn, but it means that on an idle
+cluster the label-vec is empty, and the Prometheus client omits an empty
+label-vec from `/metrics` entirely: no samples, no `HELP`, no `TYPE`.
 
 Dashboards built on the per-node gauges therefore read **no data** whenever
 nothing is tainted, which is indistinguishable from a broken or absent
 controller.
 
-Use the unlabeled `vigil_tracked_*` aggregates — and `vigil_tainted_nodes`, the
-same aggregate expressed as a node count — for dashboard panels and alerts. They
-are registered at process start, report `0` while idle, and never drop out of the
-exposition. Reach for the per-node series when drilling into which specific node
-is stuck.
+Use the unlabeled `vigil_tracked_*` aggregates and `vigil_tainted_nodes` for
+dashboard panels and alerts. They are registered at process start, report `0`
+while idle, and never drop out of the exposition. Reach for the per-node series
+when drilling into which specific node is stuck.
+
+`vigil_tainted_nodes` counts a node from the moment its taint is seen, which is
+before DaemonSet discovery has reported. A node whose discovery keeps failing
+counts there while contributing `0` to both sums — so read a progress ratio of
+`0` alongside a non-zero node count as "not yet known", not as "no DaemonSets
+are Ready".
+
+The default deployment is two replicas with leader election. Both serve
+`/metrics`, but only the leader ever sets these gauges, so the standby reports a
+permanent `0`. Wrap queries in `max without (pod, instance) (...)` to collapse
+the pair down to the leader's value — without it, panels plot two series and
+alerts fire on the standby.
 
 ```promql
-# Nodes waiting, and how far along they are — always plots, even when idle.
-vigil_tracked_ready_daemonsets / vigil_tracked_expected_daemonsets
+# How many nodes vigil is waiting on — always plots, even when idle.
+max without (pod, instance) (vigil_tainted_nodes)
+
+# Progress across those nodes. clamp_min keeps the idle case at 0: PromQL
+# follows IEEE 754, so a bare 0/0 is NaN and renders as a gap.
+max without (pod, instance) (
+  vigil_tracked_ready_daemonsets / clamp_min(vigil_tracked_expected_daemonsets, 1)
+)
 
 # Drill-down: which node is short of its expected count right now?
-vigil_expected_daemonsets - vigil_ready_daemonsets > 0
+# "or 0 *" substitutes a zero for a node that has no ready series yet, so it is
+# still listed instead of being dropped by the vector match.
+max without (pod, instance) (
+  vigil_expected_daemonsets
+    - (vigil_ready_daemonsets or 0 * vigil_expected_daemonsets)
+) > 0
 ```
 
 ## Alerting
@@ -52,11 +78,16 @@ vigil_expected_daemonsets - vigil_ready_daemonsets > 0
 Recommended alert rules:
 
 ```yaml
-# Alert if >10% of taint removals are timeouts
+# Alert if >10% of taint removals are timeouts.
+# rate() is applied per counter, then summed over the replicas: the standby's
+# counters never move, so the sum is the leader's rate.
 - alert: VigilTimeoutRate
   expr: |
-    rate(vigil_timeout_removals_total[15m])
-    / rate(vigil_successful_removals_total[15m] + vigil_timeout_removals_total[15m])
+    sum without (pod, instance) (rate(vigil_timeout_removals_total[15m]))
+    / sum without (pod, instance) (
+        rate(vigil_successful_removals_total[15m])
+        + rate(vigil_timeout_removals_total[15m])
+      )
     > 0.1
   for: 5m
 

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -14,9 +14,37 @@ weight: 20
 | `vigil_timeout_removals_total` | Counter | Taint removals due to timeout |
 | `vigil_expected_daemonsets` | Gauge (by node) | Expected DaemonSets per node |
 | `vigil_ready_daemonsets` | Gauge (by node) | Ready DaemonSet pods per node |
+| `vigil_tracked_expected_daemonsets` | Gauge | `vigil_expected_daemonsets` summed across all tracked nodes |
+| `vigil_tracked_ready_daemonsets` | Gauge | `vigil_ready_daemonsets` summed across all tracked nodes |
 | `vigil_reconcile_errors_total` | Counter | Reconciliation errors |
 | `vigil_discovery_duration_seconds` | Histogram | Time to evaluate scheduling rules |
 | `vigil_timeout_blocking_daemonset_total` | Counter (by ds) | Which DaemonSet blocked at timeout |
+
+## Per-node vs. aggregate gauges
+
+The per-node gauges carry a `node` label and exist only while vigil is tracking
+that node — from the reconcile that first sees the startup taint until the taint
+is gone or the node is deleted. This keeps cardinality bounded under node churn,
+but it means that on an idle cluster the label-vec is empty, and the Prometheus
+client omits an empty label-vec from `/metrics` entirely: no samples, no `HELP`,
+no `TYPE`.
+
+Dashboards built on the per-node gauges therefore read **no data** whenever
+nothing is tainted, which is indistinguishable from a broken or absent
+controller.
+
+Use the unlabeled `vigil_tracked_*` aggregates for dashboard panels and alerts.
+They are registered at process start, report `0` while idle, and never drop out
+of the exposition. Reach for the per-node series when drilling into which
+specific node is stuck.
+
+```promql
+# Nodes waiting, and how far along they are — always plots, even when idle.
+vigil_tracked_ready_daemonsets / vigil_tracked_expected_daemonsets
+
+# Drill-down: which node is short of its expected count right now?
+vigil_expected_daemonsets - vigil_ready_daemonsets > 0
+```
 
 ## Alerting
 


### PR DESCRIPTION
## Problem

`vigil_expected_daemonsets` and `vigil_ready_daemonsets` are label-vecs keyed by
`node`, and client_golang omits a vec with zero children from the exposition
entirely — no samples, no `HELP`, no `TYPE`.

#85 correctly stopped these series from leaking by deleting them once a node is
no longer tracked. The side effect is that a cluster with nothing currently
tainted now exposes **neither metric name at all**, which is exactly the
ambiguity #57 was filed about: a healthy-but-idle vigil looks identical to a
broken one.

Before #85 the leak accidentally papered over this — once any node had ever been
handled, the series stuck around forever. #85's own e2e commit says so directly:

> That assertion only ever passed because the per-node series leaked after
> removal — the exact behavior the previous commit fixes.

So the two goals are in real tension: bounded cardinality wants the series gone,
dashboard legibility wants them present. This PR resolves it by separating the
two concerns onto different metrics.

## Fix

Add unlabeled aggregates, summed over the tracked node set:

| Metric | Meaning |
|--------|---------|
| `vigil_tracked_expected_daemonsets` | `vigil_expected_daemonsets` summed across all tracked nodes |
| `vigil_tracked_ready_daemonsets` | `vigil_ready_daemonsets` summed across all tracked nodes |

Being unlabeled, they are registered at process start and report `0` while idle,
so panels plot a number instead of dropping out. The per-node series keep the
churn-safe lifecycle #85 gave them, for drill-down.

A single map in `pkg/metrics` backs both the per-node series and the aggregates,
under one mutex, so the two cannot diverge. The reconciler goes through
`TrackNode` / `SetNodeExpected` / `SetNodeReady` / `ForgetNode`; `ForgetNode`
replaces the local `cleanupNodeMetrics` helper.

Docs get a per-node-vs-aggregate section, corrected PromQL for panels, and a
corrected alert rule.

## Upgrade notes

Nothing here updates itself — the chart ships a ServiceMonitor but no
PrometheusRule and no dashboards, so all of the below is on the operator's own
Prometheus and Grafana config.

For context, #85 shipped in v0.6.3, so per-node gauges already vanish while idle
on the current release. **If your DaemonSet panels went blank after upgrading to
0.6.3, this is the fix.**

### Check these before rolling out

1. **`vigil_tainted_nodes` starts reporting real values.** It has been registered
   but never `Set` in every release to date, v0.6.3 included — a constant `0`. So
   any alert along the lines of `vigil_tainted_nodes > N` has never fired and has
   never been validated against real data, and can fire for the first time on
   upgrade. Worth re-reading those thresholds before they do.

2. **Standby replicas disagree with the leader.** The new `vigil_tracked_*`
   gauges read `0` on the standby. `vigil_tainted_nodes` already had a duplicate
   series, but both replicas read `0`, so it never showed; now it is leader-real
   against standby-zero. Unwrapped queries plot two conflicting series and
   threshold alerts can evaluate against the standby, so wrap them in
   `max without (pod, instance) (...)`. This is inherent to making the gauges
   always-present — it is the same property that fixes #57 — so it cannot be
   designed away, only queried around.

### Do these to get the benefit

3. **Repoint dashboards at `vigil_tracked_expected_daemonsets` /
   `vigil_tracked_ready_daemonsets`.** Panels left on the per-node gauges keep
   reading "no data" while idle. That is #85's behavior and this PR does not
   change it — switching metrics is what closes the gap.

4. **Re-copy the `VigilTimeoutRate` rule from the docs.** The previous version was
   rejected at load time, so confirm it is actually loaded in your Prometheus
   rather than assuming it has been quietly healthy.

5. **Replace any `vigil_expected_daemonsets - vigil_ready_daemonsets` drill-down
   with the documented `or 0 *` form.** The bare subtraction is an inner join and
   omits any node whose readiness check has not yet succeeded — which is exactly
   the set of nodes worth looking at.

### Deviation from the issue's proposed fix

#57 asks to "register the two gauges at startup with an initial value of 0" and
its acceptance criteria name `vigil_expected_daemonsets` / `vigil_ready_daemonsets`
specifically. That is not achievable as written — these are per-node vecs, and
there is no meaningful `node` label value at process start; a placeholder series
would be a fake node in every dashboard drill-down.

New metric names are the way to get the always-present signal without either
faking a node or reintroducing the leak. Flagging it since it means the issue's
literal acceptance criteria are not met, even though the reported problem is.

### Naming

Deliberately **not** `_total`. That is the counter convention in Prometheus and
would misrepresent a gauge to PromQL and to promlint. `TestAggregateGaugeExposition`
pins `# TYPE ... gauge` in the wire format.

## `vigil_tainted_nodes` was never actually set

It has been registered and documented since it was introduced, but **no code ever
called `Set` on it** — it always reported a constant `0`. #57 mentions it as the
metric that "existed" while the daemonset gauges were missing; it existed only
because an unlabeled gauge is always exposed, not because it carried a value.
The aggregate map already holds exactly the set of nodes vigil is waiting on, so
the count falls out of the same publish step.

An earlier revision of this description called `94d9b5e` droppable. **That is no
longer true** — `TrackNode` was added later specifically to keep this gauge
correct while DaemonSet discovery is failing, and creates no per-node series of
its own. Dropping the commit now leaves `TrackNode` doing nothing observable and
fails four tests.

## Also fixes a pre-existing docs bug

The recommended `VigilTimeoutRate` rule applies `rate()` to the sum of two range
vectors, which Prometheus rejects with `binary expression must contain only
scalar and instant vector types`. It has never loaded for anyone who pasted it.
Unrelated to #57 and predates this branch — flagging it because it is in the diff
and may explain a missing alert somewhere.

## Review round

@dcoppa reviewed and sent six patches, merged via #92. Three fixed bugs in this
PR: a documented panel query that was `0/0` = NaN and rendered as a gap in
exactly the idle case this PR exists to fix; the standby-replica problem above;
and a drill-down query whose vector match silently dropped any node whose
readiness check had not yet succeeded. Two hardened the code — the shared mutex,
and `TrackNode`. One is the alert rule above.

## Testing

- `pkg/metrics/nodes_test.go` — new. Idle exposition (the acceptance check),
  cross-node sums, replace-not-accumulate on update, expected-set-before-ready
  and admitted-before-discovery (the reconciler's two partial-update windows),
  forget arithmetic, forget-unknown no-op, gauge wire format, and a concurrent
  50-node race check for the reconciler's parallel workers.
- Extended the two #85 cleanup tests to assert the aggregate drops alongside the
  per-node series, `TestReconcile_NodeWithTaint_NotReady_Requeues` to assert a
  still-tracked node contributes to it, and added
  `TestReconcile_DiscoveryFails_NodeStillCounted` for the discovery-outage path.
- E2E: asserts the aggregates read `0` while idle **before** any taint is applied
  — the real acceptance case — and that they survive #85's per-node cleanup at
  `0` rather than disappearing.
- Every documented PromQL expression was verified against a real engine with
  `promtool test rules`, including that the previous alert rule fails to parse
  and the replacement does.
- Each fix was checked to fail without it: unregistering the aggregates fails
  `TestAggregateGaugesExposedWhenIdle`, dropping `TaintedNodes.Set` fails
  `TestTaintedNodesCountsTrackedNodes`, and removing the `TrackNode` call fails
  `TestReconcile_DiscoveryFails_NodeStillCounted`.
- `go test -race ./...` green; golangci-lint v2.11.4 (CI's pinned version) clean.

## Suggested follow-up, not in this PR

The documented PromQL has been wrong twice now, and one rule shipped broken. A CI
step running `promtool check rules` over the snippets in `metrics.md` would catch
the next one. It needs markdown extraction and a new CI dependency, so it is not
here.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
