### PR TITLE
fix(metrics): apply @dcoppa review patches — idle-case PromQL, standby replica, discovery window

### DIFF
--- a/internal/controller/node_readiness_controller.go
+++ b/internal/controller/node_readiness_controller.go
@@ -89,6 +89,10 @@ func (r *NodeReadinessReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
+	// Count the node as waiting now: discovery below can fail, and a tainted
+	// node vigil cannot evaluate must not read as no node at all.
+	metrics.TrackNode(node.Name)
+
 	nodeAge := time.Since(node.CreationTimestamp.Time).Round(time.Second)
 
 	// Check for timeout before doing discovery.

--- a/internal/controller/node_readiness_controller_test.go
+++ b/internal/controller/node_readiness_controller_test.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -284,6 +285,62 @@ func TestReconcile_NodeWithTaint_NotReady_Requeues(t *testing.T) {
 		"a still-tracked node should contribute its expected count to the aggregate")
 	assert.Equal(t, aggReadyBefore, promtestutil.ToFloat64(metrics.TrackedReadyDaemonSets),
 		"a Pending pod should contribute nothing to the ready aggregate")
+}
+
+// failingReader fails DaemonSet discovery. Discovery only ever calls List, so
+// the embedded nil Reader is enough to satisfy the interface.
+type failingReader struct {
+	client.Reader
+}
+
+func (failingReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return errors.New("apiserver unavailable")
+}
+
+// TestReconcile_DiscoveryFails_NodeStillCounted pins why TrackNode runs before
+// discovery: a tainted node vigil cannot evaluate must still show up in
+// vigil_tainted_nodes, rather than leaving the gauge at 0 and looking idle.
+func TestReconcile_DiscoveryFails_NodeStillCounted(t *testing.T) {
+	scheme := newTestScheme()
+	cfg := config.NewDefault()
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-node",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: corev1.NodeSpec{
+			Taints: []corev1.Taint{
+				{Key: cfg.TaintKey, Effect: corev1.TaintEffectNoSchedule},
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(node).
+		WithIndex(&corev1.Pod{}, readiness.NodeNameField, func(o client.Object) []string {
+			return []string{o.(*corev1.Pod).Spec.NodeName}
+		}).
+		Build()
+
+	r := newReconciler(cl, scheme, cfg)
+	r.Discovery = discovery.New(failingReader{}, logr.Discard(), cfg)
+
+	// The gauges are process-global, so measure from a known-clean baseline.
+	metrics.ForgetNode("test-node")
+	taintedBefore := promtestutil.ToFloat64(metrics.TaintedNodes)
+	seriesBefore := promtestutil.CollectAndCount(metrics.ExpectedDaemonSets)
+	t.Cleanup(func() { metrics.ForgetNode("test-node") })
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-node"},
+	})
+	require.Error(t, err, "a discovery failure should surface as a reconcile error")
+
+	assert.Equal(t, taintedBefore+1, promtestutil.ToFloat64(metrics.TaintedNodes),
+		"a tainted node must be counted even when discovery fails")
+	assert.Equal(t, seriesBefore, promtestutil.CollectAndCount(metrics.ExpectedDaemonSets),
+		"no per-node series when the expected count was never learned")
 }
 
 func TestReconcile_CatchupMetric_OldNode(t *testing.T) {

--- a/pkg/metrics/nodes.go
+++ b/pkg/metrics/nodes.go
@@ -28,8 +28,16 @@ import "sync"
 // and report 0 while idle.
 //
 // The map is the single source of truth for both, so the aggregates cannot
-// drift from the per-node series they summarize. It also backs TaintedNodes,
-// which is the same aggregate expressed as a node count.
+// drift from the per-node series they summarize. It also backs TaintedNodes:
+// note that a node admitted by TrackNode counts there while contributing 0 to
+// both sums, so the two are not interchangeable during a discovery outage.
+//
+// mu guards the per-node series as well as the map, which serializes writers
+// and keeps the two from diverging permanently under concurrent updates to the
+// same node. It does not make a scrape atomic: Gather collects the vec and the
+// aggregate gauges separately without taking this lock, so a scrape landing
+// mid-update can still see them one update apart. That skew self-corrects on
+// the next write; a permanently wrong aggregate would not.
 type nodeAggregate struct {
 	mu    sync.Mutex
 	nodes map[string]nodeCounts

--- a/pkg/metrics/nodes.go
+++ b/pkg/metrics/nodes.go
@@ -44,10 +44,10 @@ var trackedNodes = &nodeAggregate{nodes: make(map[string]nodeCounts)}
 
 // SetNodeExpected records the expected-DaemonSet count for a tracked node.
 func SetNodeExpected(nodeName string, expected int) {
-	ExpectedDaemonSets.WithLabelValues(nodeName).Set(float64(expected))
-
 	trackedNodes.mu.Lock()
 	defer trackedNodes.mu.Unlock()
+
+	ExpectedDaemonSets.WithLabelValues(nodeName).Set(float64(expected))
 	c := trackedNodes.nodes[nodeName]
 	c.expected = expected
 	trackedNodes.nodes[nodeName] = c
@@ -56,10 +56,10 @@ func SetNodeExpected(nodeName string, expected int) {
 
 // SetNodeReady records the Ready-DaemonSet-pod count for a tracked node.
 func SetNodeReady(nodeName string, ready int) {
-	ReadyDaemonSets.WithLabelValues(nodeName).Set(float64(ready))
-
 	trackedNodes.mu.Lock()
 	defer trackedNodes.mu.Unlock()
+
+	ReadyDaemonSets.WithLabelValues(nodeName).Set(float64(ready))
 	c := trackedNodes.nodes[nodeName]
 	c.ready = ready
 	trackedNodes.nodes[nodeName] = c
@@ -69,11 +69,11 @@ func SetNodeReady(nodeName string, ready int) {
 // ForgetNode drops a node from the per-node series and the aggregates once it
 // is no longer tracked, keeping per-node cardinality bounded under churn.
 func ForgetNode(nodeName string) {
-	ExpectedDaemonSets.DeleteLabelValues(nodeName)
-	ReadyDaemonSets.DeleteLabelValues(nodeName)
-
 	trackedNodes.mu.Lock()
 	defer trackedNodes.mu.Unlock()
+
+	ExpectedDaemonSets.DeleteLabelValues(nodeName)
+	ReadyDaemonSets.DeleteLabelValues(nodeName)
 	delete(trackedNodes.nodes, nodeName)
 	trackedNodes.publishLocked()
 }

--- a/pkg/metrics/nodes.go
+++ b/pkg/metrics/nodes.go
@@ -42,6 +42,25 @@ type nodeCounts struct {
 
 var trackedNodes = &nodeAggregate{nodes: make(map[string]nodeCounts)}
 
+// TrackNode records that vigil is waiting on a node, before its DaemonSet
+// counts are known. Discovery runs after this point and can fail, so admitting
+// the node here is what keeps TaintedNodes reporting it through a discovery
+// outage instead of reading 0 for nodes that are still tainted.
+//
+// No per-node series is created: an expected count of 0 would be indexed as
+// "nothing to wait for" rather than "not yet known". Until discovery reports,
+// the node counts towards TaintedNodes and contributes 0 to the sums.
+func TrackNode(nodeName string) {
+	trackedNodes.mu.Lock()
+	defer trackedNodes.mu.Unlock()
+
+	if _, ok := trackedNodes.nodes[nodeName]; ok {
+		return
+	}
+	trackedNodes.nodes[nodeName] = nodeCounts{}
+	trackedNodes.publishLocked()
+}
+
 // SetNodeExpected records the expected-DaemonSet count for a tracked node.
 func SetNodeExpected(nodeName string, expected int) {
 	trackedNodes.mu.Lock()

--- a/pkg/metrics/nodes_test.go
+++ b/pkg/metrics/nodes_test.go
@@ -93,6 +93,37 @@ func TestTaintedNodesCountsTrackedNodes(t *testing.T) {
 	assert.Equal(t, 0.0, promtestutil.ToFloat64(TaintedNodes))
 }
 
+// TestTrackNodeCountsNodeBeforeDiscovery covers the discovery-failure window:
+// the reconciler admits the node, then bails out before either count is known.
+func TestTrackNodeCountsNodeBeforeDiscovery(t *testing.T) {
+	reset(t)
+
+	TrackNode("node-a")
+
+	assert.Equal(t, 1.0, promtestutil.ToFloat64(TaintedNodes),
+		"a tainted node must be counted before its DaemonSet counts are known")
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets))
+	assert.Equal(t, 0.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+	assert.Equal(t, 0, promtestutil.CollectAndCount(ExpectedDaemonSets),
+		"no per-node series until discovery reports a count")
+	assert.Equal(t, 0, promtestutil.CollectAndCount(ReadyDaemonSets))
+}
+
+func TestTrackNodeKeepsExistingCounts(t *testing.T) {
+	reset(t)
+
+	SetNodeExpected("node-a", 5)
+	SetNodeReady("node-a", 3)
+
+	// Every reconcile of a still-tainted node calls TrackNode again.
+	TrackNode("node-a")
+
+	assert.Equal(t, 5.0, promtestutil.ToFloat64(TrackedExpectedDaemonSets),
+		"re-tracking a known node must not reset its counts")
+	assert.Equal(t, 3.0, promtestutil.ToFloat64(TrackedReadyDaemonSets))
+	assert.Equal(t, 1.0, promtestutil.ToFloat64(TaintedNodes))
+}
+
 func TestAggregateGaugesSumAcrossNodes(t *testing.T) {
 	reset(t)
 

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -23,11 +23,15 @@ weight: 20
 ## Per-node vs. aggregate gauges
 
 The per-node gauges carry a `node` label and exist only while vigil is tracking
-that node — from the reconcile that first sees the startup taint until the taint
-is gone or the node is deleted. This keeps cardinality bounded under node churn,
-but it means that on an idle cluster the label-vec is empty, and the Prometheus
-client omits an empty label-vec from `/metrics` entirely: no samples, no `HELP`,
-no `TYPE`.
+that node, disappearing once the taint is gone or the node is deleted. They also
+start late, and not together: `vigil_expected_daemonsets` appears once DaemonSet
+discovery reports a count, and `vigil_ready_daemonsets` only after a readiness
+check succeeds — so a node whose readiness check keeps failing has an expected
+series and no ready series at all.
+
+This keeps cardinality bounded under node churn, but it means that on an idle
+cluster the label-vec is empty, and the Prometheus client omits an empty
+label-vec from `/metrics` entirely: no samples, no `HELP`, no `TYPE`.
 
 Dashboards built on the per-node gauges therefore read **no data** whenever
 nothing is tainted, which is indistinguishable from a broken or absent
@@ -56,7 +60,12 @@ max without (pod, instance) (
 )
 
 # Drill-down: which node is short of its expected count right now?
-max without (pod, instance) (vigil_expected_daemonsets - vigil_ready_daemonsets) > 0
+# "or 0 *" substitutes a zero for a node that has no ready series yet, so it is
+# still listed instead of being dropped by the vector match.
+max without (pod, instance) (
+  vigil_expected_daemonsets
+    - (vigil_ready_daemonsets or 0 * vigil_expected_daemonsets)
+) > 0
 ```
 
 ## Alerting

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -73,11 +73,16 @@ max without (pod, instance) (
 Recommended alert rules:
 
 ```yaml
-# Alert if >10% of taint removals are timeouts
+# Alert if >10% of taint removals are timeouts.
+# rate() is applied per counter, then summed over the replicas: the standby's
+# counters never move, so the sum is the leader's rate.
 - alert: VigilTimeoutRate
   expr: |
-    rate(vigil_timeout_removals_total[15m])
-    / rate(vigil_successful_removals_total[15m] + vigil_timeout_removals_total[15m])
+    sum without (pod, instance) (rate(vigil_timeout_removals_total[15m]))
+    / sum without (pod, instance) (
+        rate(vigil_successful_removals_total[15m])
+        + rate(vigil_timeout_removals_total[15m])
+      )
     > 0.1
   for: 5m
 

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -39,16 +39,24 @@ are registered at process start, report `0` while idle, and never drop out of th
 exposition. Reach for the per-node series when drilling into which specific node
 is stuck.
 
+The default deployment is two replicas with leader election. Both serve
+`/metrics`, but only the leader ever sets these gauges, so the standby reports a
+permanent `0`. Wrap queries in `max without (pod, instance) (...)` to collapse
+the pair down to the leader's value — without it, panels plot two series and
+alerts fire on the standby.
+
 ```promql
 # How many nodes vigil is waiting on — always plots, even when idle.
-vigil_tainted_nodes
+max without (pod, instance) (vigil_tainted_nodes)
 
 # Progress across those nodes. clamp_min keeps the idle case at 0: PromQL
 # follows IEEE 754, so a bare 0/0 is NaN and renders as a gap.
-vigil_tracked_ready_daemonsets / clamp_min(vigil_tracked_expected_daemonsets, 1)
+max without (pod, instance) (
+  vigil_tracked_ready_daemonsets / clamp_min(vigil_tracked_expected_daemonsets, 1)
+)
 
 # Drill-down: which node is short of its expected count right now?
-vigil_expected_daemonsets - vigil_ready_daemonsets > 0
+max without (pod, instance) (vigil_expected_daemonsets - vigil_ready_daemonsets) > 0
 ```
 
 ## Alerting

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -40,8 +40,12 @@ exposition. Reach for the per-node series when drilling into which specific node
 is stuck.
 
 ```promql
-# Nodes waiting, and how far along they are — always plots, even when idle.
-vigil_tracked_ready_daemonsets / vigil_tracked_expected_daemonsets
+# How many nodes vigil is waiting on — always plots, even when idle.
+vigil_tainted_nodes
+
+# Progress across those nodes. clamp_min keeps the idle case at 0: PromQL
+# follows IEEE 754, so a bare 0/0 is NaN and renders as a gap.
+vigil_tracked_ready_daemonsets / clamp_min(vigil_tracked_expected_daemonsets, 1)
 
 # Drill-down: which node is short of its expected count right now?
 vigil_expected_daemonsets - vigil_ready_daemonsets > 0

--- a/website/content/en/docs/reference/metrics.md
+++ b/website/content/en/docs/reference/metrics.md
@@ -37,11 +37,16 @@ Dashboards built on the per-node gauges therefore read **no data** whenever
 nothing is tainted, which is indistinguishable from a broken or absent
 controller.
 
-Use the unlabeled `vigil_tracked_*` aggregates — and `vigil_tainted_nodes`, the
-same aggregate expressed as a node count — for dashboard panels and alerts. They
-are registered at process start, report `0` while idle, and never drop out of the
-exposition. Reach for the per-node series when drilling into which specific node
-is stuck.
+Use the unlabeled `vigil_tracked_*` aggregates and `vigil_tainted_nodes` for
+dashboard panels and alerts. They are registered at process start, report `0`
+while idle, and never drop out of the exposition. Reach for the per-node series
+when drilling into which specific node is stuck.
+
+`vigil_tainted_nodes` counts a node from the moment its taint is seen, which is
+before DaemonSet discovery has reported. A node whose discovery keeps failing
+counts there while contributing `0` to both sums — so read a progress ratio of
+`0` alongside a non-zero node count as "not yet known", not as "no DaemonSets
+are Ready".
 
 The default deployment is two replicas with leader election. Both serve
 `/metrics`, but only the leader ever sets these gauges, so the standby reports a


### PR DESCRIPTION
Applies all six patches @dcoppa attached to #91, authorship preserved, plus one
commit of my own. Targets `feat/aggregate-daemonset-gauges` so #91 picks it up.

**All six are correct and I verified each one rather than eyeballing it.** Three
of them are bugs in code or docs I wrote in #91; one is pre-existing on `main`.

## Verification

The four PromQL claims, checked against a real engine with `promtool test rules`
(offline unit tests, no server) rather than by reading:

| Claim | Result |
|---|---|
| Idle `0/0` ratio is NaN → Grafana gap | confirmed, engine returned `NaN` |
| Standby replica yields a second, conflicting `0` series | confirmed; `max without (pod, instance)` collapses to the leader's value |
| Plain subtraction inner-joins and drops a node with no ready series | confirmed dropped; `or 0 *` keeps it |
| Existing `VigilTimeoutRate` rule does not parse | confirmed: `binary expression must contain only scalar and instant vector types` |

The two Go patches:

- **Patch 3** — reverted the `TrackNode` call and `TestReconcile_DiscoveryFails_NodeStillCounted` fails. Real gap, real test.
- **Patch 1** — the probe below diverges *permanently* (`per-node series=1 but aggregate=100`) without the lock. See the note on it though.

`go test -race ./...` green, golangci-lint v2.11.4 (CI's version) 0 issues.

## The three that are my bugs

**Patch 2 is the one that stings.** The query I documented as "always plots, even
when idle" was `vigil_tracked_ready_daemonsets / vigil_tracked_expected_daemonsets`
— both `0` on an idle cluster, and PromQL follows IEEE 754, so that is `0/0` =
NaN, which Grafana renders as a gap. The headline example for the fix reproduced
the exact symptom #57 is about.

**Patch 4 is the most consequential, and it is a problem my change introduced.**
The default deployment is two replicas with leader election (`replicaCount: 2`,
`leaderElection.enabled: true` — I checked the chart), and controller-runtime
starts the metrics server on non-leaders too. Before #91 the standby's empty
label-vecs produced nothing at all. Pre-registered *unlabeled* gauges always
produce a series, so #91 gives every standby a permanent `0` alongside the
leader's real value: two conflicting series on every panel, and zero-valued
alerts firing on the standby. Making the gauges always-present is exactly what
creates this, so it belongs in this PR and not a follow-up.

**Patch 5** is the readiness-check-fails window in the drill-down query. Same
class of mistake as patch 2 — I wrote PromQL without testing it against the
partial states the reconciler actually produces.

## Patch 6 is pre-existing

`VigilTimeoutRate` applies `rate()` to the sum of two range vectors. It has never
loaded for anyone who pasted it. Not from #91 — worth noting in case it explains
a missing alert somewhere.

## One note on patch 1, not a blocker

The code is right and I would take it, but the stated rationale — "a reader could
observe the per-node series and the aggregate disagreeing" — is not what the
change achieves. `Gather` collects the vec and the aggregate gauges separately
and never takes `trackedNodes.mu`, so a scrape landing mid-update can still see
them one update apart. Real atomicity would need a custom `Collector`.

What the lock does buy is worth having, and is a stronger reason than the one
given: without it, two concurrent writers for the same node can leave the vec and
the map *permanently* disagreeing, not just transiently. I could not reproduce
that by chance in 2000 attempts — the window is a few instructions — but with a
`runtime.Gosched()` widening it, it reproduces in ~33 iterations. controller-runtime
serializes reconciles per object key, so today no caller can trigger it; this is
defensive, and appropriate for a package-level API that should not depend on its
caller's concurrency model.

I left the commit message alone rather than rewrite someone else's history, and
instead recorded the accurate guarantee as a comment in `nodes.go`. Happy to
squash that into patch 1 if @dcoppa prefers.

## My commit

Two claims of mine that the patches invalidate:

- `vigil_tainted_nodes` is no longer "the same aggregate expressed as a node
  count". Patch 3 admits a node before discovery reports, so a node with failing
  discovery counts there while contributing `0` to both sums. Unstated, a reader
  sees a `0` ratio against a non-zero node count and concludes nothing is Ready,
  when the counts are simply unknown.
- The `nodeAggregate` comment now says what the mutex does and does not
  guarantee, per the note above.

## Suggested follow-up, deliberately not here

The documented PromQL has now been wrong twice, and one rule shipped broken for
who knows how long. A CI step running `promtool check rules` over the snippets in
`metrics.md` would catch the next one. It needs markdown extraction and a new CI
dependency, so it does not belong in this PR — I have the test file from the
verification above if it is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)